### PR TITLE
[AUTH] jwt 인증 끝나면 사용자에게 다시 토큰 전달

### DIFF
--- a/src/main/java/com/ani/taku_backend/config/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ani/taku_backend/config/filter/JwtAuthenticationFilter.java
@@ -47,6 +47,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             try {
                 PrincipalUser principalUser = new PrincipalUser(jwtUtil.getUserFromToken(accessToken));
+                response.setHeader("Authorization", "Bearer " + accessToken);
                 SecurityContextHolder.getContext().setAuthentication(
                     new UsernamePasswordAuthenticationToken(principalUser, null, null)
                 );


### PR DESCRIPTION

## Description
- jwt 필터에서 인증 완료 시 다시 사용자에게 token response

## 참고
- refresh할때는 다시 전달하기 때문에 refresh가 아닐때도 전달하여 일방적으로 계속 토큰 전달
