### PR TITLE
[FILE] r2 cdn url을 공용 url로 처리할 수 잇도록 변경

### DIFF
--- a/src/main/java/com/ani/taku_backend/common/service/FileService.java
+++ b/src/main/java/com/ani/taku_backend/common/service/FileService.java
@@ -2,8 +2,10 @@ package com.ani.taku_backend.common.service;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -19,16 +21,29 @@ public class FileService {
 
     private final AmazonS3 client;
 
+    @Value("${cloud.flare.public.url}")
+    private String publicUrl;
+
     @Value("${cloud.flare.bucket}")
     private String bucket;
 
     public String uploadFile(MultipartFile file) throws IOException {
         String fileName = generateFileName(file.getOriginalFilename());
+        
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentLength(file.getSize());
+        metadata.setContentType(file.getContentType());  // Content-Type 설정
+        
+        // ACL을 public-read로 설정
+        PutObjectRequest putObjectRequest = new PutObjectRequest(
+            bucket, 
+            fileName, 
+            file.getInputStream(), 
+            metadata
+        ).withCannedAcl(CannedAccessControlList.PublicRead);  // public-read ACL 추가
 
-        client.putObject(bucket, fileName, file.getInputStream(), metadata);
-        return client.getUrl(bucket, fileName).toString(); // 업로드된 파일의 URL 반환
+        client.putObject(putObjectRequest);
+        return publicUrl + "/" + fileName;
     }
 
     private String generateFileName(String originalFilename) {


### PR DESCRIPTION
## Description
- 기존에 파일 서비스 에서 제공하는 r2 cdn url을 직접 들어갈 경우 403forbidden error로 인해 정상적으로 이미지,파일을 볼 수 없었으며
- r2에서 제공하는 public url을 통해 가져올 수 잇도록 변경
- 
## Changes
- r2 에서 제공하는 public url로 변경   !!application.yml 값  추가 필요!!

