### PR TITLE
[COMMON] Extract keyword api

### DIFF
--- a/src/main/java/com/ani/taku_backend/common/model/dto/ExtractKeywordDTO.java
+++ b/src/main/java/com/ani/taku_backend/common/model/dto/ExtractKeywordDTO.java
@@ -1,0 +1,15 @@
+package com.ani.taku_backend.common.model.dto;
+
+import java.util.List;
+
+import lombok.Data;
+import lombok.ToString;
+
+@Data
+@ToString
+public class ExtractKeywordDTO {
+
+    private String text;
+    private List<String> keywords;
+    
+}

--- a/src/main/java/com/ani/taku_backend/common/service/ExtractKeywordService.java
+++ b/src/main/java/com/ani/taku_backend/common/service/ExtractKeywordService.java
@@ -1,0 +1,46 @@
+package com.ani.taku_backend.common.service;
+
+import java.util.HashMap;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import com.ani.taku_backend.common.model.dto.ExtractKeywordDTO;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ExtractKeywordService {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${flask.url}")
+    private String flaskUrl;
+
+    public List<String> extractKeywords(String text) {
+
+        if(text == null || text.isEmpty()) {
+            log.error("Text is null or empty");
+            return null;
+        }
+
+        HashMap<String, String> request = new HashMap<>();
+        request.put("text", text);
+
+        ResponseEntity<ExtractKeywordDTO> response = this.restTemplate.postForEntity(this.flaskUrl, request, ExtractKeywordDTO.class);
+
+        if(response.getStatusCode() != HttpStatus.OK) {
+            log.error("Failed to extract keywords");
+            return null;
+        }
+
+        return response.getBody().getKeywords();
+    }
+}

--- a/src/main/java/com/ani/taku_backend/config/RestTemplateConfig.java
+++ b/src/main/java/com/ani/taku_backend/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.ani.taku_backend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+    
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/ani/taku_backend/user/model/dto/PrincipalUser.java
+++ b/src/main/java/com/ani/taku_backend/user/model/dto/PrincipalUser.java
@@ -32,11 +32,6 @@ public class PrincipalUser implements UserDetails {
     public Long getUserId() {
         return user.getUserId();
     }
-
-    public User getUser() {
-        return user;
-    }
-
     // 권한 반환
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {


### PR DESCRIPTION
## Description
- AWS에 flask 서버로 텍스트 분할 api 요청 서비스 추가

## Changes
- RestTemplate Config추가
- application.yml 값 추가필요

`
flask:
  url: http://***********:5000/extract-keywords
`

- ErrorCode 오타로 인한 수정
- PrincipalUser getUser 메소드 중복으로인한 수정 

## Screenshots
- Flask서버로 요청 확인 및 값 확인

![image](https://github.com/user-attachments/assets/cce41b39-5ed7-48d2-a24d-8ea4dfea155a)

