### PR TITLE
[TEST][BUGFIX] updatePost에서 넘어온 이미지가 없을 때 삭제가 되지 않았던 버그를 수정

### DIFF
--- a/src/main/java/com/ani/taku_backend/post/service/PostService.java
+++ b/src/main/java/com/ani/taku_backend/post/service/PostService.java
@@ -169,6 +169,11 @@ public class PostService {
             imageRepository.softDeleteByFileNames(filesToDelete);
         }
 
+        // 새로 추가된 파일 필터링 (기존 파일과 중복되지 않은 파일만 선택)
+        List<MultipartFile> filesToAdd = imageList.stream()
+                .filter(file -> !existingFileNames.contains(file.getOriginalFilename()))
+                .toList();
+
         // 새 파일 업로드 및 저장
         for (MultipartFile image : imageList) {
             try {

--- a/src/main/java/com/ani/taku_backend/post/service/PostService.java
+++ b/src/main/java/com/ani/taku_backend/post/service/PostService.java
@@ -175,7 +175,7 @@ public class PostService {
                 .toList();
 
         // 새 파일 업로드 및 저장
-        for (MultipartFile image : imageList) {
+        for (MultipartFile image : filesToAdd) {
             try {
                 String imageUrl = fileService.uploadFile(image);
                 processImage(requestDTO, user, post, imageUrl);

--- a/src/main/java/com/ani/taku_backend/post/service/PostService.java
+++ b/src/main/java/com/ani/taku_backend/post/service/PostService.java
@@ -106,9 +106,8 @@ public class PostService {
         }
 
         // 이미지 수정
-        if (imageList != null && !imageList.isEmpty()) {
-            updateImages(postUpdateRequestDTO, imageList, user, post);
-        }
+        updateImages(postUpdateRequestDTO, imageList, user, post);
+
         // 게시글 수정
         post.updatePost(postUpdateRequestDTO.getTitle(), postUpdateRequestDTO.getContent(), newCategory);
 
@@ -118,6 +117,7 @@ public class PostService {
     /**
      * 게시글 삭제
      */
+    @RequireUser
     @Transactional
     public Long deletePost(Long postId, PrincipalUser principalUser) {
         User user = principalUser.getUser();
@@ -136,7 +136,8 @@ public class PostService {
         return post.getId();
     }
 
-    private void saveImages(PostCreateUpdateRequestDTO postCreateRequestDTO, List<MultipartFile> imageList, User user, Post post) {
+    @Transactional
+    protected void saveImages(PostCreateUpdateRequestDTO postCreateRequestDTO, List<MultipartFile> imageList, User user, Post post) {
         for (MultipartFile image : imageList) {
             try {
                 String imageUrl = fileService.uploadFile(image);
@@ -149,12 +150,19 @@ public class PostService {
         }
     }
 
-    private void updateImages(PostCreateUpdateRequestDTO requestDTO, List<MultipartFile> imageList, User user, Post post) {
+    @Transactional
+    protected void updateImages(PostCreateUpdateRequestDTO requestDTO, List<MultipartFile> imageList, User user, Post post) {
         if (requestDTO.getImagelist() != null) {
             validateImageCount(requestDTO.getImagelist());
         }
 
-        if (imageList == null || imageList.isEmpty()) return;
+        if (imageList == null || imageList.isEmpty()) {
+            post.getCommunityImages().forEach(communityImage -> {
+                Image image = communityImage.getImage();
+                image.softDelete(); // Soft delete 호출
+            });
+            return;
+        }
 
         List<String> existingFileNames = imageRepository.findFileNamesByPostId(post.getId());
         List<String> newFileNames = imageList.stream().map(MultipartFile::getOriginalFilename).toList();
@@ -185,8 +193,8 @@ public class PostService {
         }
     }
 
-
-    private void processImage(PostCreateUpdateRequestDTO requestDTO, User user, Post post, String imageUrl) {
+    @Transactional
+    void processImage(PostCreateUpdateRequestDTO requestDTO, User user, Post post, String imageUrl) {
         String fileName = imageUrl.substring(imageUrl.lastIndexOf("/") + 1);
 
         for (ImageCreateRequestDTO imageDTO : requestDTO.getImagelist()) {

--- a/src/test/java/com/ani/taku_backend/post/service/PostServiceTest.java
+++ b/src/test/java/com/ani/taku_backend/post/service/PostServiceTest.java
@@ -4,11 +4,13 @@ import com.ani.taku_backend.category.domain.entity.Category;
 import com.ani.taku_backend.category.domain.repository.CategoryRepository;
 import com.ani.taku_backend.common.enums.SortFilterType;
 import com.ani.taku_backend.common.exception.PostException;
+import com.ani.taku_backend.common.model.entity.Image;
 import com.ani.taku_backend.common.repository.ImageRepository;
 import com.ani.taku_backend.common.service.FileService;
 import com.ani.taku_backend.post.model.dto.PostCreateUpdateRequestDTO;
 import com.ani.taku_backend.post.model.dto.PostDetailResponseDTO;
 import com.ani.taku_backend.post.model.dto.PostListResponseDTO;
+import com.ani.taku_backend.post.model.entity.CommunityImage;
 import com.ani.taku_backend.post.model.entity.Post;
 import com.ani.taku_backend.post.repository.PostRepository;
 import com.ani.taku_backend.user.model.dto.PrincipalUser;
@@ -26,6 +28,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.sql.SQLOutput;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
@@ -49,6 +52,8 @@ class PostServiceTest {
     TestFixture testFixture;
     @Autowired
     private UserRepository userRepository;
+    @Autowired
+    private ImageRepository imageRepository;
 
     //    @Test
     void init() {
@@ -148,7 +153,7 @@ class PostServiceTest {
         assertThat(post.getUser().getNickname()).isEqualTo(principalUser.getUser().getNickname());
     }
 
-//    @Test
+    @Test
     @Transactional
     void updatePost() {
         PrincipalUser principalUser = (PrincipalUser) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
@@ -168,11 +173,17 @@ class PostServiceTest {
         Post updatePost = postRepository.findById(updatePostId).get();
         System.out.println("최초 제목 = " + findTitle + " 수정한 제목 = " + updatePost.getTitle());
         System.out.println("최초 내용 = " + findContent + " 수정한 내용 = " + updatePost.getContent());
+
+        updatePost.getCommunityImages().forEach(communityImage -> {
+            System.out.println("파일 이름 = " + communityImage.getImage().getFileName() +
+                             " deleteAt = " + communityImage.getImage().getDeletedAt());
+        });
+
         assertThat("수정한 제목").isEqualTo(updatePost.getTitle());
         assertThat("수정한 내용").isEqualTo(updatePost.getContent());
     }
 
-//    @Test
+    @Test
     @Transactional
     void deletePost() {
         PrincipalUser principalUser = (PrincipalUser) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
@@ -187,10 +198,11 @@ class PostServiceTest {
 
         Post post = postRepository.findById(deletePostId).get();
         System.out.println("삭제 일시 = " + post.getDeletedAt());
+
         assertThat(post.getDeletedAt()).isNotNull();
     }
 
-//    @Test
+    @Test
     void findPostDetail() {
         Random random = new Random();
         long randomPostId = random.nextLong(1, 3000);

--- a/src/test/java/com/ani/taku_backend/post/service/PostServiceTest.java
+++ b/src/test/java/com/ani/taku_backend/post/service/PostServiceTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -124,7 +125,7 @@ class PostServiceTest {
         var authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
 
         // SecurityContext에 PrincipalUser 설정
-        var authentication = new org.springframework.security.authentication.UsernamePasswordAuthenticationToken(principalUser, null, authorities);
+        var authentication = new UsernamePasswordAuthenticationToken(principalUser, null, authorities);
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 
@@ -147,7 +148,7 @@ class PostServiceTest {
         assertThat(post.getUser().getNickname()).isEqualTo(principalUser.getUser().getNickname());
     }
 
-    @Test
+//    @Test
     @Transactional
     void updatePost() {
         PrincipalUser principalUser = (PrincipalUser) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
@@ -171,7 +172,7 @@ class PostServiceTest {
         assertThat("수정한 내용").isEqualTo(updatePost.getContent());
     }
 
-    @Test
+//    @Test
     @Transactional
     void deletePost() {
         PrincipalUser principalUser = (PrincipalUser) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
@@ -189,7 +190,7 @@ class PostServiceTest {
         assertThat(post.getDeletedAt()).isNotNull();
     }
 
-    @Test
+//    @Test
     void findPostDetail() {
         Random random = new Random();
         long randomPostId = random.nextLong(1, 3000);


### PR DESCRIPTION
## Changes
- updatePost 내부 updateImages 수정
- - 넘어온 image리스트가 null일때 아무런 조치를 취하지않고 그냥 반환하던 로직을 수정하여 null로 넘어오면 기존에 등록했던 이미지를 모두 삭제한 것으로 간주하고 이미지들을 softdelete가 되도록 수정

- test 진행
- - 이미지 list가 null로 입력되어있을때 정상적으로 수정된 글에 첨부된 이미지들의 delete_at 필드에 날짜가 입력되는 것을 확인