### PR TITLE
[FEAUTRE] 싫어요 추가 및 취소 기능 추가

### DIFF
--- a/src/main/java/com/ani/taku_backend/shorts/domain/entity/Shorts.java
+++ b/src/main/java/com/ani/taku_backend/shorts/domain/entity/Shorts.java
@@ -49,18 +49,38 @@ public class Shorts {
     @CreatedDate
     private LocalDateTime createdAt;
 
-    public void addLike(boolean hasDislike) {
+    public void addLikeCount(boolean hasDislike) {
         if(hasDislike) {
-            int dislikes = this.popularityMetrics.dislikes;
-            if(dislikes > 0) {
-                this.popularityMetrics.dislikes -= 1;
-            }
+            decreaseDislikeCount();
         }
+        increaseLikeCount();
+    }
+
+    public void addDislikeCount(boolean haslike) {
+        if(haslike) {
+            decreaseLikeCount();
+        }
+        increaseDislikeCount();
+    }
+
+    private void increaseLikeCount() {
         this.popularityMetrics.likes += 1;
     }
 
-    public void decreaseLike() {
-        this.popularityMetrics.likes -= 1;
+    public void decreaseLikeCount() {
+        if(this.popularityMetrics.likes > 0) {
+            this.popularityMetrics.likes -= 1;
+        }
+    }
+
+    private void increaseDislikeCount() {
+        this.popularityMetrics.dislikes += 1;
+    }
+
+    public void decreaseDislikeCount() {
+        if(this.popularityMetrics.dislikes > 0) {
+            this.popularityMetrics.dislikes -= 1;
+        }
     }
 
     @Getter

--- a/src/main/java/com/ani/taku_backend/shorts_interaction/controller/ShortsInteractionController.java
+++ b/src/main/java/com/ani/taku_backend/shorts_interaction/controller/ShortsInteractionController.java
@@ -49,7 +49,7 @@ public class ShortsInteractionController {
 
     @Operation(summary = "Shorts 좋아요 취소", description = "쇼츠 동영상에 좋아요한 유저가 취소를 누름")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "쇼츠 좋아요 취소간 다 완료."),
+            @ApiResponse(responseCode = "200", description = "쇼츠 좋아요 취소 완료."),
             @ApiResponse(responseCode = "403", description = "회원 인증이 되지 않았습니다."),
             @ApiResponse(responseCode = "404", description = "쇼츠 정보를 찾을 수 없습니다.")
     })
@@ -63,6 +63,41 @@ public class ShortsInteractionController {
 
         return CommonResponse.ok(null);
     }
+
+    @Operation(summary = "Shorts 싫어요", description = "쇼츠 동영상에 로그인 한 유저가 싫어요를 누름")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "쇼츠 좋아요 생성 완료."),
+            @ApiResponse(responseCode = "403", description = "회원 인증이 되지 않았습니다."),
+            @ApiResponse(responseCode = "404", description = "쇼츠 정보를 찾을 수 없습니다.")
+    })
+    @PostMapping("/{shortsId}/dislikes")
+    public CommonResponse<Void> addDislike(@AuthenticationPrincipal PrincipalUser userPrincipal,
+        @Parameter(description = "쇼츠 아이디", required = true) @PathVariable("shortsId") String shortsId) {
+        User user = userPrincipal.getUser();
+        validateBlackUser(user.getUserId());
+
+        interactionService.addDislike(user, shortsId);
+
+        return CommonResponse.ok(null);
+    }
+
+    @Operation(summary = "Shorts 싫어요 취소", description = "쇼츠 동영상에 싫어요한 유저가 취소를 누름")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "쇼츠 싫어요 취소 완료."),
+            @ApiResponse(responseCode = "403", description = "회원 인증이 되지 않았습니다."),
+            @ApiResponse(responseCode = "404", description = "쇼츠 정보를 찾을 수 없습니다.")
+    })
+    @PostMapping("/{shortsId}/dislikes/cancel")
+    public CommonResponse<Void> cancelDislike(@AuthenticationPrincipal PrincipalUser userPrincipal,
+        @Parameter(description = "쇼츠 아이디", required = true) @PathVariable("shortsId") String shortsId) {
+        User user = userPrincipal.getUser();
+        validateBlackUser(user.getUserId());
+
+        interactionService.cancelDislike(user, shortsId);
+
+        return CommonResponse.ok(null);
+    }
+
 
     private void validateBlackUser(Long userId) {
         List<BlackUser> blackUser = blackUserService.findByUserId(userId);

--- a/src/main/java/com/ani/taku_backend/shorts_interaction/repository/CustomInteractionRepository.java
+++ b/src/main/java/com/ani/taku_backend/shorts_interaction/repository/CustomInteractionRepository.java
@@ -16,4 +16,6 @@ public interface CustomInteractionRepository {
 
     Optional<UserInteractionResponse> findUserLikeInteractions(Long userId, String shortsId);
 
+    Optional<UserInteractionResponse> findUserDislikeInteractions(Long userId, String shortsId);
+
 }

--- a/src/main/java/com/ani/taku_backend/shorts_interaction/repository/CustomInteractionRepositoryImpl.java
+++ b/src/main/java/com/ani/taku_backend/shorts_interaction/repository/CustomInteractionRepositoryImpl.java
@@ -131,4 +131,30 @@ public class CustomInteractionRepositoryImpl implements CustomInteractionReposit
 
         return Optional.ofNullable(results.getUniqueMappedResult());
     }
+
+    @Override
+    public Optional<UserInteractionResponse> findUserDislikeInteractions(Long userId, String shortsId) {
+        if(userId == null) {
+            return Optional.empty();
+        }
+        MatchOperation match = Aggregation.match(
+                Criteria
+                        .where(InteractionField.SHORTS_ID.getFieldName()).is(new ObjectId(shortsId))
+                        .and(InteractionField.USER_ID.getFieldName()).is(userId)
+                        .and(InteractionField.INTERACTION_TYPE.getFieldName()).is(InteractionType.DISLIKE.getValue())
+        );
+
+        ProjectionOperation projection = Aggregation.project()
+                .and(InteractionField.ID.getFieldName()).as(InteractionField.ID.getVariableName())
+                .and(InteractionField.SHORTS_ID.getFieldName()).as(InteractionField.SHORTS_ID.getVariableName())
+                .and(InteractionField.USER_ID.getFieldName()).as(InteractionField.USER_ID.getVariableName());
+
+        Aggregation aggregation = Aggregation.newAggregation(match, projection);
+
+        AggregationResults<UserInteractionResponse> results = mongoTemplate.aggregate(
+                aggregation, Interaction.class, UserInteractionResponse.class
+        );
+
+        return Optional.ofNullable(results.getUniqueMappedResult());
+    }
 }

--- a/src/main/java/com/ani/taku_backend/shorts_interaction/service/InteractionService.java
+++ b/src/main/java/com/ani/taku_backend/shorts_interaction/service/InteractionService.java
@@ -7,4 +7,8 @@ public interface InteractionService {
     void addLike(User user, String shortsId);
 
     void cancelLike(User user, String shortsId);
+
+    void addDislike(User user, String shortsId);
+
+    void cancelDislike(User user, String shortsId);
 }

--- a/src/main/java/com/ani/taku_backend/shorts_interaction/service/InteractionServiceImpl.java
+++ b/src/main/java/com/ani/taku_backend/shorts_interaction/service/InteractionServiceImpl.java
@@ -34,8 +34,8 @@ public class InteractionServiceImpl implements InteractionService {
 
         // 좋아요가 없을 때
         if(userLikeInterAction.getLike() == null) {
-            boolean hasDislike = userLikeInterAction.getDislike() == null;
-            shorts.addLike(hasDislike);
+            boolean hasDislike = userLikeInterAction.getDislike() != null;
+            shorts.addLikeCount(hasDislike);
             Interaction interaction = Interaction.create(shorts, user.getUserId(), InteractionType.LIKE);
 
             shortsRepository.save(shorts);
@@ -59,7 +59,48 @@ public class InteractionServiceImpl implements InteractionService {
 
         if(userLikeInterActionOptional.isPresent()) {
             UserInteractionResponse interactionResponse = userLikeInterActionOptional.get();
-            shorts.decreaseLike();
+            shorts.decreaseLikeCount();
+            shortsRepository.save(shorts);
+            interactionRepository.deleteById(new ObjectId(interactionResponse.getId()));
+        }
+    }
+
+    @Transactional
+    @Override
+    public void addDislike(User user, String shortsId) {
+        Shorts shorts = shortsRepository.findById(shortsId)
+                            .orElseThrow(FileException.FileNotFoundException::new);
+
+        InteractionResponse userLikeInterAction = interactionRepository.findUserLikeDislikeInteractions(user.getUserId(), shortsId);
+
+        // 싫어요가 없을 때만 추가
+        if(userLikeInterAction.getDislike() == null) {
+            boolean hasLike = userLikeInterAction.getLike() != null;
+            shorts.addDislikeCount(hasLike);
+            Interaction dislikeInteraction = Interaction.create(shorts, user.getUserId(), InteractionType.DISLIKE);
+
+            shortsRepository.save(shorts);
+            if(hasLike) {
+                String likeId = userLikeInterAction.getLike().getId();
+                Interaction likeInteraction = interactionRepository.findById(new ObjectId(likeId))
+                        .orElseThrow(() -> new DuckwhoException(ErrorCode.NOT_FOUND_INTERACTION));
+                interactionRepository.delete(likeInteraction);
+            }
+            interactionRepository.save(dislikeInteraction);
+        }
+    }
+
+    @Transactional
+    @Override
+    public void cancelDislike(User user, String shortsId) {
+        Shorts shorts = shortsRepository.findById(shortsId)
+                .orElseThrow(FileException.FileNotFoundException::new);
+
+        Optional<UserInteractionResponse> userDislikeInterActionOptional = interactionRepository.findUserDislikeInteractions(user.getUserId(), shortsId);
+
+        if(userDislikeInterActionOptional.isPresent()) {
+            UserInteractionResponse interactionResponse = userDislikeInterActionOptional.get();
+            shorts.decreaseDislikeCount();
             shortsRepository.save(shorts);
             interactionRepository.deleteById(new ObjectId(interactionResponse.getId()));
         }


### PR DESCRIPTION
## Description
- 싫어요는 로그인을 한 사용자 중 블랙 유저가 아닌 사용자가 할 수 있는 행동입니다.
- 싫어요는 사용자 당 하나의 쇼츠에서 한 번씩만  할 수 있습니다.

## Changes
- 좋아요 증가 메서드 이름 변경 : 명시적으로 shorts에서는 수량을 늘리기 때문에 increaseCount처럼 갯수를 메서드명에 붙임
- 싫어요 추가 및 싫어요 취소 기능 추가
## Screenshots
- 화면이 추가되거나 변경된 경우 스크린샷을 첨부해주세요. (없어도 무관)
- 상태의 변경이나 플로우 같은 동적인 동작은 영상을 촬영하여 첨부해주세요. (없어도 무관)

## Ref
- Notion의 관련 Task 링크를 입력해주세요. (없어도 무관)
- 화면명세에 대한 Figma 링크를 입력해주세요. (없어도 무관)
- 참고한 문서에 대한 링크를 입력해주세요. (없어도 무관)
