### PR TITLE
[HOTFIX] 로그인 요청시 header에 유저정보 추가

### DIFF
--- a/src/main/java/com/ani/taku_backend/auth/service/OAuth2UserService.java
+++ b/src/main/java/com/ani/taku_backend/auth/service/OAuth2UserService.java
@@ -1,18 +1,14 @@
 package com.ani.taku_backend.auth.service;
 
-import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
 import com.ani.taku_backend.user.model.entity.User;
 import com.ani.taku_backend.user.repository.UserRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import com.ani.taku_backend.user.service.BlackUserService;
+
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -21,13 +17,9 @@ import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
-
 import com.ani.taku_backend.auth.util.JwtUtil;
 import com.ani.taku_backend.common.service.RedisService;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 
@@ -45,6 +37,8 @@ public class OAuth2UserService extends DefaultOAuth2UserService {
     private final JwtUtil jwtUtil;
     private final UserRepository userRepository;
     private final RedisService redisService;
+    private final BlackUserService blackUserService;
+
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -80,8 +74,12 @@ public class OAuth2UserService extends DefaultOAuth2UserService {
                             redirectUrl.toUriString() // uri (React 프로젝트 주소)
                     ));
         }
+
+        boolean isBlack = this.blackUserService.findByUserId(findOptUser.get().getUserId()).isEmpty() ? false : true;
+
         try{
             attributes.put("user", findOptUser.get());
+            attributes.put("is_black", isBlack);
         } catch (Exception e) {
             log.error("유저 정보 추출 실패", e);
             throw new OAuth2AuthenticationException("유저 정보 추출 실패");


### PR DESCRIPTION
## Description
- 프론트엔드에서 유저정보를 가져다 쓸 용도로 로그인 페이지 리다이렉트 시 request header에 유저 정보 json값 추가

## Changes
- 핸들러
  - setHeader , userToJson 기능 추가
  - 블랙유저 검증 서비스 호출

## Screenshots
- 헤더 정상응답 확인
![image](https://github.com/user-attachments/assets/704d99a6-892d-40c1-ba3a-d8ab92ce3260)

- 헤더 Base64 디코딩 시 데이터 확인
- 
![image](https://github.com/user-attachments/assets/14526de6-3555-42ad-8623-d68a4214cf09)


## Ref
- [Notion 프론트엔드 요청 회의록](https://www.notion.so/fbc127b8a1d14dc884d673cd382d02ce?pvs=4)
