### PR TITLE
[INTERACTION] 시청 기록 추가 API

### DIFF
--- a/src/main/java/com/ani/taku_backend/shorts/domain/entity/Interaction.java
+++ b/src/main/java/com/ani/taku_backend/shorts/domain/entity/Interaction.java
@@ -1,28 +1,23 @@
 package com.ani.taku_backend.shorts.domain.entity;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
+import com.ani.taku_backend.common.enums.InteractionType;
+import com.ani.taku_backend.shorts.domain.vo.InteractionDetail;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
 import org.bson.types.ObjectId;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
-import com.ani.taku_backend.common.enums.InteractionType;
-import com.ani.taku_backend.shorts.domain.vo.InteractionDetail;
-
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Document(collection = "interactions")
 @Getter
 @Builder
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @ToString
 public class Interaction<T extends InteractionDetail> {
@@ -46,23 +41,20 @@ public class Interaction<T extends InteractionDetail> {
     @Field("created_at")
     private LocalDateTime createdAt;
 
-    public static Interaction create(Shorts shorts, Long userId, InteractionType interactionType, InteractionDetail details) {
-        return Interaction.builder()
-                .shortsId(new ObjectId(shorts.getId()))
-                .userId(userId)
-                .interactionType(interactionType)
-                .shortsTags(shorts.getTags())
-                .details(details)
-                .build();
+    public static Interaction createLike(Shorts shorts, Long userId) {
+        return new Interaction(shorts, userId, InteractionType.LIKE, null);
     }
 
-    public static Interaction create(Shorts shorts, Long userId, InteractionType interactionType) {
-        return Interaction.builder()
-                .shortsId(new ObjectId(shorts.getId()))
-                .userId(userId)
-                .interactionType(interactionType)
-                .shortsTags(shorts.getTags())
-                .build();
+    public static Interaction createView(Shorts shorts, Long userId, InteractionDetail detail) {
+        return new Interaction(shorts, userId, InteractionType.VIEW, detail);
+    }
+
+    private Interaction(Shorts shorts, Long userId, InteractionType type, InteractionDetail details) {
+        this.shortsId = new ObjectId(shorts.getId());
+        this.userId = userId;
+        this.interactionType = type;
+        this.shortsTags = shorts.getTags();
+        this.details = (T)details;
     }
 }
 

--- a/src/main/java/com/ani/taku_backend/shorts_interaction/controller/ShortsInteractionController.java
+++ b/src/main/java/com/ani/taku_backend/shorts_interaction/controller/ShortsInteractionController.java
@@ -3,6 +3,8 @@ package com.ani.taku_backend.shorts_interaction.controller;
 import com.ani.taku_backend.common.exception.DuckwhoException;
 import com.ani.taku_backend.common.exception.ErrorCode;
 import com.ani.taku_backend.common.response.CommonResponse;
+import com.ani.taku_backend.shorts_interaction.domain.dto.CreateShortsViewDTO;
+import com.ani.taku_backend.shorts_interaction.domain.dto.req.CreateShortsViewReqDTO;
 import com.ani.taku_backend.shorts_interaction.service.InteractionService;
 import com.ani.taku_backend.user.model.dto.PrincipalUser;
 import com.ani.taku_backend.user.model.entity.BlackUser;
@@ -17,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -60,6 +63,30 @@ public class ShortsInteractionController {
         validateBlackUser(user.getUserId());
 
         interactionService.cancelLike(user, shortsId);
+
+        return CommonResponse.ok(null);
+    }
+
+    @Operation(summary = "Shorts 시청 기록", description = "사용자가 쇼츠를 시청한 데이터 추가. 다음 쇼츠로 넘어가거나 페이지를 벗어날 때 사용.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "쇼츠 좋아요 취소간 다 완료."),
+            @ApiResponse(responseCode = "403", description = "회원 인증이 되지 않았습니다."),
+            @ApiResponse(responseCode = "404", description = "쇼츠 정보를 찾을 수 없습니다.")
+    })
+    @PostMapping("/{shortsId}/view")
+    public CommonResponse<Void> createView(@AuthenticationPrincipal PrincipalUser userPrincipal,
+        @Parameter(description = "쇼츠 아이디", required = true) @PathVariable("shortsId") String shortsId,
+        @RequestBody CreateShortsViewReqDTO createShortsViewReqDTO) {
+        User user = userPrincipal.getUser();
+        validateBlackUser(user.getUserId());
+
+        CreateShortsViewDTO createShortsViewDTO = CreateShortsViewDTO.builder()
+                .shortsId(shortsId)
+                .viewDuration(createShortsViewReqDTO.getViewTime())
+                .playDuration(createShortsViewReqDTO.getPlayTime())
+                .user(user)
+                .build();
+        interactionService.createView(createShortsViewDTO);
 
         return CommonResponse.ok(null);
     }

--- a/src/main/java/com/ani/taku_backend/shorts_interaction/controller/ShortsInteractionController.java
+++ b/src/main/java/com/ani/taku_backend/shorts_interaction/controller/ShortsInteractionController.java
@@ -15,8 +15,10 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -26,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @Tag(name = "Shorts 상호작용 API", description = "Shorts 관련 좋아요, 싫어요 등 상호작용 API")
+@Validated
 @RequestMapping("/api/shorts")
 @RestController
 @RequiredArgsConstructor
@@ -76,7 +79,7 @@ public class ShortsInteractionController {
     @PostMapping("/{shortsId}/view")
     public CommonResponse<Void> createView(@AuthenticationPrincipal PrincipalUser userPrincipal,
         @Parameter(description = "쇼츠 아이디", required = true) @PathVariable("shortsId") String shortsId,
-        @RequestBody CreateShortsViewReqDTO createShortsViewReqDTO) {
+        @Valid @RequestBody CreateShortsViewReqDTO createShortsViewReqDTO) {
         User user = userPrincipal.getUser();
         validateBlackUser(user.getUserId());
 

--- a/src/main/java/com/ani/taku_backend/shorts_interaction/domain/dto/CreateShortsViewDTO.java
+++ b/src/main/java/com/ani/taku_backend/shorts_interaction/domain/dto/CreateShortsViewDTO.java
@@ -1,24 +1,21 @@
-package com.ani.taku_backend.shorts.domain.vo;
+package com.ani.taku_backend.shorts_interaction.domain.dto;
 
+import com.ani.taku_backend.user.model.entity.User;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 import java.time.Duration;
 
-/**
- * 쇼츠 조회 상세 정보 (조회 시간, 조회 비율)
- */
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@ToString
-public class ViewDetail implements InteractionDetail {
-    private Duration playDuration;
+public class CreateShortsViewDTO {
+    private String shortsId;
+    private User user;
     private Duration viewDuration;
-    private Double viewRatio;
+    private Duration playDuration;
 }

--- a/src/main/java/com/ani/taku_backend/shorts_interaction/domain/dto/req/CreateShortsViewReqDTO.java
+++ b/src/main/java/com/ani/taku_backend/shorts_interaction/domain/dto/req/CreateShortsViewReqDTO.java
@@ -2,6 +2,7 @@ package com.ani.taku_backend.shorts_interaction.domain.dto.req;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,9 +14,11 @@ import java.time.Duration;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreateShortsViewReqDTO {
+    @NotBlank
     @Schema(name = "viewTime", description = "사용자가 쇼츠를 시청한 시간. 60초 짜리 동영상을 모두 보고 추가로 10초를 보면 시청 시간은 70초가 됨.", example = "PT1M30S")
     @JsonFormat(shape = JsonFormat.Shape.STRING)
     private Duration viewTime;
+    @NotBlank
     @Schema(name = "playTime", description = "해당 쇼츠의 총 재생 시간.", example = "PT30S")
     @JsonFormat(shape = JsonFormat.Shape.STRING)
     private Duration playTime;

--- a/src/main/java/com/ani/taku_backend/shorts_interaction/domain/dto/req/CreateShortsViewReqDTO.java
+++ b/src/main/java/com/ani/taku_backend/shorts_interaction/domain/dto/req/CreateShortsViewReqDTO.java
@@ -1,0 +1,22 @@
+package com.ani.taku_backend.shorts_interaction.domain.dto.req;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Duration;
+
+@Schema(name = "쇼츠 재생 기록 요청 객체", description = "쇼츠 재생 기록 생성에 필요한 객체.")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateShortsViewReqDTO {
+    @Schema(name = "viewTime", description = "사용자가 쇼츠를 시청한 시간. 60초 짜리 동영상을 모두 보고 추가로 10초를 보면 시청 시간은 70초가 됨.", example = "PT1M30S")
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    private Duration viewTime;
+    @Schema(name = "playTime", description = "해당 쇼츠의 총 재생 시간.", example = "PT30S")
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    private Duration playTime;
+}

--- a/src/main/java/com/ani/taku_backend/shorts_interaction/service/InteractionService.java
+++ b/src/main/java/com/ani/taku_backend/shorts_interaction/service/InteractionService.java
@@ -1,5 +1,6 @@
 package com.ani.taku_backend.shorts_interaction.service;
 
+import com.ani.taku_backend.shorts_interaction.domain.dto.CreateShortsViewDTO;
 import com.ani.taku_backend.user.model.entity.User;
 
 public interface InteractionService {
@@ -7,4 +8,6 @@ public interface InteractionService {
     void addLike(User user, String shortsId);
 
     void cancelLike(User user, String shortsId);
+
+    void createView(CreateShortsViewDTO createShortsViewReqDTO);
 }

--- a/src/main/java/com/ani/taku_backend/shorts_interaction/service/InteractionServiceImpl.java
+++ b/src/main/java/com/ani/taku_backend/shorts_interaction/service/InteractionServiceImpl.java
@@ -1,21 +1,24 @@
 package com.ani.taku_backend.shorts_interaction.service;
 
-import com.ani.taku_backend.common.enums.InteractionType;
 import com.ani.taku_backend.common.exception.DuckwhoException;
 import com.ani.taku_backend.common.exception.ErrorCode;
 import com.ani.taku_backend.common.exception.FileException;
 import com.ani.taku_backend.shorts.domain.entity.Interaction;
 import com.ani.taku_backend.shorts.domain.entity.Shorts;
+import com.ani.taku_backend.shorts.domain.vo.ViewDetail;
 import com.ani.taku_backend.shorts.repository.ShortsRepository;
+import com.ani.taku_backend.shorts_interaction.domain.dto.CreateShortsViewDTO;
 import com.ani.taku_backend.shorts_interaction.domain.dto.InteractionResponse;
 import com.ani.taku_backend.shorts_interaction.domain.dto.UserInteractionResponse;
 import com.ani.taku_backend.shorts_interaction.repository.InteractionRepository;
 import com.ani.taku_backend.user.model.entity.User;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.bson.types.ObjectId;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Optional;
 
 @Service
@@ -36,7 +39,7 @@ public class InteractionServiceImpl implements InteractionService {
         if(userLikeInterAction.getLike() == null) {
             boolean hasDislike = userLikeInterAction.getDislike() == null;
             shorts.addLike(hasDislike);
-            Interaction interaction = Interaction.create(shorts, user.getUserId(), InteractionType.LIKE);
+            Interaction interaction = Interaction.createLike(shorts, user.getUserId());
 
             shortsRepository.save(shorts);
             if(hasDislike) {
@@ -63,6 +66,27 @@ public class InteractionServiceImpl implements InteractionService {
             shortsRepository.save(shorts);
             interactionRepository.deleteById(new ObjectId(interactionResponse.getId()));
         }
+    }
+
+    @org.springframework.transaction.annotation.Transactional
+    @Override
+    public void createView(CreateShortsViewDTO createShortsViewReqDTO) {
+        Shorts shorts = shortsRepository.findById(createShortsViewReqDTO.getShortsId())
+                .orElseThrow(FileException.FileNotFoundException::new);
+
+        BigDecimal playTime = BigDecimal.valueOf(createShortsViewReqDTO.getPlayDuration().toNanos());
+        BigDecimal viewTime = BigDecimal.valueOf(createShortsViewReqDTO.getViewDuration().toNanos());
+        BigDecimal viewRatio = viewTime.divide(playTime, 4, RoundingMode.HALF_UP);
+
+        ViewDetail detail = ViewDetail.builder()
+                .playDuration(createShortsViewReqDTO.getPlayDuration())
+                .viewDuration(createShortsViewReqDTO.getViewDuration())
+                .viewRatio(viewRatio.doubleValue())
+                .build();
+
+        Interaction interaction = Interaction.createView(shorts,createShortsViewReqDTO.getUser().getUserId(), detail);
+        interactionRepository.save(interaction);
+
     }
 
 }


### PR DESCRIPTION
<!--
 리뷰 요청자와 리뷰어 간의 생산적이고 효율적인 리뷰 진행을 위해 아래 나열된 내용을 참고해서 PR 설명을 작성해주세요!
-->

## Description
- 사용자가 쇼츠를 볼 때 해당 쇼츠를 50%이상 본다면 해당 쇼츠와 비슷한 것들을 추천 알고리즘에서 추가할 수 있어야 합니다.
- 재생시간, 시청시간 등에 대한 시간 형식은 https://ko.wikipedia.org/wiki/ISO_8601 를 따릅니다.
- 시청시간 / 재생시간의 비율은 1.9612처럼 소수점 4자리 까지 저장합니다.
   - 시청시간 / 재생시간이 1.9612라면 하나의 쇼츠를 1.9612번 봤다라고 해석될 수 있습니다.

## Changes
- Interaction에 대한 type별 static 객체 생성 메서드를 분리
  - 매개변수를 받는 부분은 private 생성자로 만들어 객체 내에서 사용 될 수 있게 변경
- Duration은 "PT33S" (33초)로 해석 됨.
- 매개변수가 많기 때문에 Controller Layout에서 Service Layout으로 데이터를 보낼 때 계층 별 결합도를 낮추고 매개변수를 줄이기 위해 Controller에서 받는 ReqDTO와 전달 객체 DTO를 따로 분리
- 부동 소수점의 정확한 계산을 위해 BigDecimal을 사용

## Screenshots
- 화면이 추가되거나 변경된 경우 스크린샷을 첨부해주세요. (없어도 무관)
- 상태의 변경이나 플로우 같은 동적인 동작은 영상을 촬영하여 첨부해주세요. (없어도 무관)

## Ref
- Notion의 관련 Task 링크를 입력해주세요. (없어도 무관)
- 화면명세에 대한 Figma 링크를 입력해주세요. (없어도 무관)
- 참고한 문서에 대한 링크를 입력해주세요. (없어도 무관)
