### PR TITLE
[feature] 공통 요청 api작업을 위한 코드 추가 및 수정

### DIFF
--- a/src/main/java/com/ani/taku_backend/common/annotation/RequireUser.java
+++ b/src/main/java/com/ani/taku_backend/common/annotation/RequireUser.java
@@ -13,4 +13,6 @@ import java.lang.annotation.Target;
 public @interface RequireUser {
     // 관리자 권한 필요 여부
     boolean isAdmin() default false;
+
+    boolean allowAnonymous() default false;
 }

--- a/src/main/java/com/ani/taku_backend/config/SecurityConfig.java
+++ b/src/main/java/com/ani/taku_backend/config/SecurityConfig.java
@@ -15,6 +15,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import com.ani.taku_backend.auth.handler.OAuth2AuthenticationHandler;
 import com.ani.taku_backend.auth.service.OAuth2UserService;
 import com.ani.taku_backend.config.filter.JwtAuthenticationFilter;
+import com.ani.taku_backend.config.filter.PublicEndpointFilter;
 import com.ani.taku_backend.config.filter.RefreshTokenFilter;
 
 import lombok.RequiredArgsConstructor;
@@ -36,7 +37,7 @@ public class SecurityConfig {
     private final OAuth2AuthenticationHandler.OAuth2FailureHandler oAuth2FailureHandler;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final RefreshTokenFilter refreshTokenFilter;
-    
+    private final PublicEndpointFilter publicEndpointFilter;
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
@@ -68,7 +69,8 @@ public class SecurityConfig {
                 .failureHandler(this.oAuth2FailureHandler)
             )
             .addFilterBefore(refreshTokenFilter, UsernamePasswordAuthenticationFilter.class)
-            .addFilterBefore(jwtAuthenticationFilter, RefreshTokenFilter.class);
+            .addFilterBefore(publicEndpointFilter, RefreshTokenFilter.class)
+            .addFilterBefore(jwtAuthenticationFilter, PublicEndpointFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/ani/taku_backend/config/filter/PublicEndpointFilter.java
+++ b/src/main/java/com/ani/taku_backend/config/filter/PublicEndpointFilter.java
@@ -1,0 +1,89 @@
+package com.ani.taku_backend.config.filter;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.ani.taku_backend.auth.util.JwtUtil;
+import com.ani.taku_backend.common.exception.ErrorCode;
+import com.ani.taku_backend.common.response.CommonResponse;
+import com.ani.taku_backend.user.model.dto.PrincipalUser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * 공개 엔드포인트 필터
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PublicEndpointFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        log.info("PublicEndpointFilter");
+
+        // SecurityContext에서 인증 객체 확인
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        
+        // TODO: jwt 인증 완료된 요청 처리 공통 함수 처리
+        if (authentication != null && authentication.isAuthenticated()) {
+            log.info("JWT 인증 완료된 요청: {}", authentication.getName());
+        } else {
+
+            String authorizationHeader = request.getHeader("Authorization");
+            if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+                String accessToken = authorizationHeader.substring(7);
+
+                try {
+                    PrincipalUser principalUser = new PrincipalUser(jwtUtil.getUserFromToken(accessToken));
+                    log.info("principalUser : {}", principalUser);
+                    response.setHeader("Authorization", "Bearer " + accessToken);
+                    SecurityContextHolder.getContext().setAuthentication(
+                        new UsernamePasswordAuthenticationToken(principalUser, null, null)
+                    );
+
+                } catch (ExpiredJwtException e) {
+                    // 토큰이 만료되었을 때 요청 속성에 더 자세한 정보를 담아서 전달
+                    request.setAttribute("expired", true);
+                    request.setAttribute("expiredToken", accessToken);  // 만료된 토큰 정보
+                    request.setAttribute("expiredTokenClaims", e.getClaims());  // 만료된 토큰의 클레임 정보
+                } catch (Exception e) {
+                    handleInvalidToken(response, e);
+                    return;
+                }
+            }else{
+                log.info("anonymous user");
+            }
+        }
+        
+        filterChain.doFilter(request, response);
+    }
+        // 유효하지 않은 토큰 처리
+    private void handleInvalidToken(HttpServletResponse response, Exception e) throws IOException {
+        log.error("유효하지 않은 토큰", e);
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType("application/json;charset=UTF-8");
+
+        CommonResponse<Void> errorResponse = CommonResponse.fail(ErrorCode.INVALID_TOKEN);
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/com/ani/taku_backend/config/filter/RefreshTokenFilter.java
+++ b/src/main/java/com/ani/taku_backend/config/filter/RefreshTokenFilter.java
@@ -12,7 +12,6 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.ani.taku_backend.auth.util.JwtUtil;
 import com.ani.taku_backend.common.exception.UserException.UserNotFoundException;
-import com.ani.taku_backend.config.SecurityPathConfig;
 import com.ani.taku_backend.user.model.dto.PrincipalUser;
 import com.ani.taku_backend.user.model.entity.User;
 
@@ -140,14 +139,5 @@ public class RefreshTokenFilter extends OncePerRequestFilter {
     private void handleUnauthorized(HttpServletResponse response, String message) throws IOException {
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.getWriter().write(message);
-    }
-
-    // 필터 스킵 여부 결정
-    @Override
-    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-        return SecurityPathConfig.shouldSkipFilter(
-            request.getRequestURI(), 
-            request.getMethod()
-        );
     }
 }

--- a/src/main/java/com/ani/taku_backend/user/model/dto/PrincipalUser.java
+++ b/src/main/java/com/ani/taku_backend/user/model/dto/PrincipalUser.java
@@ -10,14 +10,23 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import com.ani.taku_backend.common.enums.StatusType;
+import com.ani.taku_backend.user.model.entity.User;
+
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 /**
  * 스프링 시큐리티에 저장할 유저 정보
  */
 @ToString
 @RequiredArgsConstructor
+@AllArgsConstructor
 public class PrincipalUser implements UserDetails {
 
     private User user;
+
+    private boolean isAnonymous;
 
     public PrincipalUser(User user) {
         this.user = user;
@@ -61,5 +70,9 @@ public class PrincipalUser implements UserDetails {
     @Override
     public boolean isEnabled() {
         return StatusType.ACTIVE.name().equals(user.getStatus());
+    }
+
+    public boolean isAnonymous() {
+        return isAnonymous;
     }
 }


### PR DESCRIPTION
## Description
- 비로그인/로그인 공통 api호출을 위한 aop및 필터 수정

### 수정한 이유
- 현재 상황으로 모든api에 대해 비로그인/로그인에 대한 검증을 개별적으로 달 수 없기때문에
   기존 필터에 대한 스킵여부를 변경하지 않고
   공통필터를 사용하여 비로그인/로그인에 대한 세션정보를 가져올 수 있도록 필터 추가

공통필터
- jwt토큰이 있다면 기존과 같이 검증 , 토큰이 없다면 anonymous 로 취급하여 에러없이 필터체이닝

필터 순서
- jwt -> publicEndpoint -> refreshToken

## Changes

### 수정
-  RequireUser
  - anonymous - 익명여부 필드 추가
- SecurityAspect ( AOP )
  -  익명여부필드 검사 후 PrincipalUser 발급
- SecurityConfig
  - PublicEndpointFilter  공통 사용 필터 추가
- RefreshTokenFilter
  - 어차피 jwtfilter 뒤 호출되어 검증,미검증을 확인하며 스킵여부가 불필요하다 생각하여 삭제


### 추가
- PublicEndpointFilter
  - 전체 api에 대한 jwt토큰 확인 & 익명유저 확인을 위한 전역필터

