### PR TITLE
[feature] 덕후장터 유저 interaction 추가

### DIFF
--- a/src/main/java/com/ani/taku_backend/common/annotation/RequireUser.java
+++ b/src/main/java/com/ani/taku_backend/common/annotation/RequireUser.java
@@ -13,4 +13,6 @@ import java.lang.annotation.Target;
 public @interface RequireUser {
     // 관리자 권한 필요 여부
     boolean isAdmin() default false;
+
+    boolean allowAnonymous() default false;
 }

--- a/src/main/java/com/ani/taku_backend/common/enums/LogType.java
+++ b/src/main/java/com/ani/taku_backend/common/enums/LogType.java
@@ -1,0 +1,11 @@
+package com.ani.taku_backend.common.enums;
+
+public enum LogType {
+    SEARCH("search"), VIEW("view");
+
+    private final String value;
+
+    LogType(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/com/ani/taku_backend/config/SecurityConfig.java
+++ b/src/main/java/com/ani/taku_backend/config/SecurityConfig.java
@@ -15,6 +15,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import com.ani.taku_backend.auth.handler.OAuth2AuthenticationHandler;
 import com.ani.taku_backend.auth.service.OAuth2UserService;
 import com.ani.taku_backend.config.filter.JwtAuthenticationFilter;
+import com.ani.taku_backend.config.filter.PublicEndpointFilter;
 import com.ani.taku_backend.config.filter.RefreshTokenFilter;
 
 import lombok.RequiredArgsConstructor;
@@ -36,7 +37,7 @@ public class SecurityConfig {
     private final OAuth2AuthenticationHandler.OAuth2FailureHandler oAuth2FailureHandler;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final RefreshTokenFilter refreshTokenFilter;
-    
+    private final PublicEndpointFilter publicEndpointFilter;
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
@@ -68,7 +69,8 @@ public class SecurityConfig {
                 .failureHandler(this.oAuth2FailureHandler)
             )
             .addFilterBefore(refreshTokenFilter, UsernamePasswordAuthenticationFilter.class)
-            .addFilterBefore(jwtAuthenticationFilter, RefreshTokenFilter.class);
+            .addFilterBefore(publicEndpointFilter, RefreshTokenFilter.class)
+            .addFilterBefore(jwtAuthenticationFilter, PublicEndpointFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/ani/taku_backend/config/filter/PublicEndpointFilter.java
+++ b/src/main/java/com/ani/taku_backend/config/filter/PublicEndpointFilter.java
@@ -1,0 +1,89 @@
+package com.ani.taku_backend.config.filter;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.ani.taku_backend.auth.util.JwtUtil;
+import com.ani.taku_backend.common.exception.ErrorCode;
+import com.ani.taku_backend.common.response.CommonResponse;
+import com.ani.taku_backend.user.model.dto.PrincipalUser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * 공개 엔드포인트 필터
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PublicEndpointFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        log.info("PublicEndpointFilter");
+
+        // SecurityContext에서 인증 객체 확인
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        
+        // TODO: jwt 인증 완료된 요청 처리 공통 함수 처리
+        if (authentication != null && authentication.isAuthenticated()) {
+            log.info("JWT 인증 완료된 요청: {}", authentication.getName());
+        } else {
+
+            String authorizationHeader = request.getHeader("Authorization");
+            if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+                String accessToken = authorizationHeader.substring(7);
+
+                try {
+                    PrincipalUser principalUser = new PrincipalUser(jwtUtil.getUserFromToken(accessToken));
+                    log.info("principalUser : {}", principalUser);
+                    response.setHeader("Authorization", "Bearer " + accessToken);
+                    SecurityContextHolder.getContext().setAuthentication(
+                        new UsernamePasswordAuthenticationToken(principalUser, null, null)
+                    );
+
+                } catch (ExpiredJwtException e) {
+                    // 토큰이 만료되었을 때 요청 속성에 더 자세한 정보를 담아서 전달
+                    request.setAttribute("expired", true);
+                    request.setAttribute("expiredToken", accessToken);  // 만료된 토큰 정보
+                    request.setAttribute("expiredTokenClaims", e.getClaims());  // 만료된 토큰의 클레임 정보
+                } catch (Exception e) {
+                    handleInvalidToken(response, e);
+                    return;
+                }
+            }else{
+                log.info("anonymous user");
+            }
+        }
+        
+        filterChain.doFilter(request, response);
+    }
+        // 유효하지 않은 토큰 처리
+    private void handleInvalidToken(HttpServletResponse response, Exception e) throws IOException {
+        log.error("유효하지 않은 토큰", e);
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType("application/json;charset=UTF-8");
+
+        CommonResponse<Void> errorResponse = CommonResponse.fail(ErrorCode.INVALID_TOKEN);
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/com/ani/taku_backend/config/filter/RefreshTokenFilter.java
+++ b/src/main/java/com/ani/taku_backend/config/filter/RefreshTokenFilter.java
@@ -12,7 +12,6 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.ani.taku_backend.auth.util.JwtUtil;
 import com.ani.taku_backend.common.exception.UserException.UserNotFoundException;
-import com.ani.taku_backend.config.SecurityPathConfig;
 import com.ani.taku_backend.user.model.dto.PrincipalUser;
 import com.ani.taku_backend.user.model.entity.User;
 
@@ -140,14 +139,5 @@ public class RefreshTokenFilter extends OncePerRequestFilter {
     private void handleUnauthorized(HttpServletResponse response, String message) throws IOException {
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.getWriter().write(message);
-    }
-
-    // 필터 스킵 여부 결정
-    @Override
-    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-        return SecurityPathConfig.shouldSkipFilter(
-            request.getRequestURI(), 
-            request.getMethod()
-        );
     }
 }

--- a/src/main/java/com/ani/taku_backend/jangter/model/entity/UserInteraction.java
+++ b/src/main/java/com/ani/taku_backend/jangter/model/entity/UserInteraction.java
@@ -1,0 +1,75 @@
+package com.ani.taku_backend.jangter.model.entity;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import org.bson.types.ObjectId;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import com.ani.taku_backend.common.enums.LogType;
+import com.ani.taku_backend.common.enums.SortFilterType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Document(collection = "user_interactions")
+@ToString
+public class UserInteraction<T extends UserInteraction.LogDetail> {
+    @Id
+    private ObjectId id;
+    
+    @Field("user_id")
+    private Long userId;
+
+    @Field("interaction_type")
+    private LogType logType;
+
+    @Field("log_detail")
+    private T logDetail;
+
+    @Field("created_at")
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    public interface LogDetail {}
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ToString
+    public static class SearchLogDetail implements LogDetail {
+        @Field("search_keyword")
+        private String searchKeyword;
+
+        @Field("search_category")
+        private List<Long> searchCategory;
+
+        @Field("sort_type")
+        private SortFilterType sortType;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ToString
+    public static class ViewLogDetail implements LogDetail {
+        @Field("product_id")
+        private Long productId;
+    }
+}
+
+
+

--- a/src/main/java/com/ani/taku_backend/jangter/service/UserInteractionService.java
+++ b/src/main/java/com/ani/taku_backend/jangter/service/UserInteractionService.java
@@ -1,0 +1,68 @@
+package com.ani.taku_backend.jangter.service;
+
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Service;
+
+import com.ani.taku_backend.common.annotation.RequireUser;
+import com.ani.taku_backend.common.enums.LogType;
+import com.ani.taku_backend.jangter.model.entity.UserInteraction;
+import com.ani.taku_backend.user.model.dto.PrincipalUser;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserInteractionService {
+
+    private final MongoTemplate mongoTemplate;
+
+    /**
+     * 사용자 상호작용 로그 저장
+     * @param <T> 로그 상세 정보 타입
+     * @param userId 사용자 ID
+     * @param logType 로그 유형
+     * @param logDetail 로그 상세 정보
+     */
+    @RequireUser(allowAnonymous = true)
+    public <T extends UserInteraction.LogDetail> void saveLog(PrincipalUser principalUser, LogType logType, T logDetail) {
+
+        if(principalUser.getUser() == null) {
+            return;
+        }
+
+        UserInteraction<T> interaction = UserInteraction.<T>builder()
+            .userId(principalUser.getUserId())
+            .logType(logType)
+            .logDetail(logDetail)
+            .createdAt(LocalDateTime.now())
+            .build();
+
+        try{
+            mongoTemplate.save(interaction);
+        } catch (Exception e) {
+            log.error("Failed to save log : {}", e.getMessage());
+        }
+    }
+
+    public List<UserInteraction> findLatestByUserId(Long userId , LogType logType) {
+        LocalDateTime sevenDaysAgo = LocalDateTime.now().minusDays(7);
+
+        Query query = Query.query(
+            Criteria.where("user_id").is(userId)
+            .and("interaction_type").is(logType)
+            .and("created_at").gte(sevenDaysAgo)
+        )
+        .with(Sort.by(Sort.Direction.DESC, "created_at"));
+
+        return mongoTemplate.find(query, UserInteraction.class);
+    }
+}
+

--- a/src/main/java/com/ani/taku_backend/user/model/dto/PrincipalUser.java
+++ b/src/main/java/com/ani/taku_backend/user/model/dto/PrincipalUser.java
@@ -10,14 +10,23 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import com.ani.taku_backend.common.enums.StatusType;
+import com.ani.taku_backend.user.model.entity.User;
+
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 /**
  * 스프링 시큐리티에 저장할 유저 정보
  */
 @ToString
 @RequiredArgsConstructor
+@AllArgsConstructor
 public class PrincipalUser implements UserDetails {
 
     private User user;
+
+    private boolean isAnonymous;
 
     public PrincipalUser(User user) {
         this.user = user;
@@ -61,5 +70,9 @@ public class PrincipalUser implements UserDetails {
     @Override
     public boolean isEnabled() {
         return StatusType.ACTIVE.name().equals(user.getStatus());
+    }
+
+    public boolean isAnonymous() {
+        return isAnonymous;
     }
 }


### PR DESCRIPTION
## Description
- 추후 개발될 추천 api에 대해 덕후장터 user interactions 서비스 추가

## Changes
- user interactions 관련 서비스 및 document entity 추가

## Screenshots

### 값 추가 정상확인
![image](https://github.com/user-attachments/assets/7c5e50a1-f542-40de-9abe-41839815fc64)

### 사용 방법
UserInteractionService -> saveLog 함수 호출

```java        
/**
 * 사용자 상호작용 로그 저장
 * @param <T> 로그 상세 정보 타입
 * @param userId 사용자 ID. ----> 내부 aop로 인해 null로 요청
 * @param logType 로그 유형   -----> enum에 맞춰 api별로 다르게 요청
 * @param logDetail 로그 상세 정보   -----> UserInteraction class의 내부클래스에 맞게 동적 요청
 */
this.userInteractionService.saveLog(null, LogType.VIEW, ViewLogDetail.builder().productId(productId).build());
this.userInteractionService.saveLog(null, LogType.SEARCH, 
    SearchLogDetail.builder()
        .searchKeyword(null) // 검색 시 사용한 키워드
        .searchCategory(null)  // 검색 한 상품의 카테고리 
        .sortType(SortFilterType.LATEST)
        .build()
);
);

```


