### PR TITLE
[hotfix] 쇼츠 댓글조회 api수정

### DIFF
--- a/src/main/java/com/ani/taku_backend/shorts/domain/dto/ShortsCommentDTO.java
+++ b/src/main/java/com/ani/taku_backend/shorts/domain/dto/ShortsCommentDTO.java
@@ -14,6 +14,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Data
 @Builder
@@ -75,6 +76,12 @@ public class ShortsCommentDTO {
         }
     }
 
+    @Setter
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "쇼츠 댓글 대댓글 정보")
     public static class CommentReplyDTO{
         @Schema(description = "쇼츠 댓글 대댓글 아이디")
         @JsonProperty("id")
@@ -86,6 +93,14 @@ public class ShortsCommentDTO {
         @JsonProperty("user_id")
         @Schema(description = "쇼츠 댓글 대댓글 작성자 아이디")
         private Long userId;
+
+        @JsonProperty("nickname")
+        @Schema(description = "쇼츠 댓글 대댓글 작성자 닉네임")
+        private String nickname;
+
+        @JsonProperty("profile_image")
+        @Schema(description = "쇼츠 댓글 대댓글 작성자 프로필 이미지")
+        private String profileImage;
 
         @JsonProperty("created_at")
         @Schema(description = "쇼츠 댓글 대댓글 생성 시간")


### PR DESCRIPTION


## Description
- 쇼츠 댓글 api 수정
  - 대댓글 조회 시 user_id 만 응답하던 부분 -> 유저 정보 ( 닉네임 , 프로필사진 이미지 ) 전달하도록 수정

## Screenshots
- 대댓글에도 유저 정보가 전달되도록 수정
![image](https://github.com/user-attachments/assets/4be53576-a222-47a0-8084-435efa0a18ff)

## Ref
- Notion의 관련 Task 링크를 입력해주세요. (없어도 무관)
- 화면명세에 대한 Figma 링크를 입력해주세요. (없어도 무관)
- 참고한 문서에 대한 링크를 입력해주세요. (없어도 무관)
