### PR TITLE
[ 시세 그래프 응답 DTO] datapoints에 상품 id와 title까지 함께 전달

### DIFF
--- a/src/main/java/com/ani/taku_backend/marketprice/controller/CompletedDealController.java
+++ b/src/main/java/com/ani/taku_backend/marketprice/controller/CompletedDealController.java
@@ -7,12 +7,14 @@ import com.ani.taku_backend.marketprice.model.dto.PriceGraphRequestDTO;
 import com.ani.taku_backend.marketprice.service.CompletedDealService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 @Slf4j
 @Tag(name = "시세 조회 API", description = "상품 시세 조회 관련 API")
@@ -26,15 +28,21 @@ public class CompletedDealController {
     @Operation(summary = "시세 조회", description = "키워드로 상품 시세를 조회합니다.")
     @GetMapping("/search")
     public CommonResponse<MarketPriceSearchResponseDTO> searchMarketPrice(
-            @Valid @ModelAttribute PriceGraphRequestDTO requestDTO,
+            @RequestParam String keyword,
+            @RequestParam String startDate,
+            @RequestParam String endDate,
             @RequestParam(required = false, defaultValue = "ALL") GraphDisplayOption displayOption,
             @PageableDefault(size = 5) Pageable pageable
     ) {
         try {
-            log.debug("시세 조회 요청 - requestDTO: {}, displayOption: {}, pageable: {}",
-                    requestDTO, displayOption, pageable);
+            log.debug("시세 조회 요청 - keyword: {}, startDate: {}, endDate: {}, displayOption: {}, pageable: {}",
+                    keyword, startDate, endDate, displayOption, pageable);
 
-            requestDTO.setDisplayOption(displayOption);
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+            LocalDate parsedStartDate = LocalDate.parse(startDate, formatter);
+            LocalDate parsedEndDate = LocalDate.parse(endDate, formatter);
+
+            var requestDTO = new PriceGraphRequestDTO(keyword, parsedStartDate, parsedEndDate, displayOption);
 
             MarketPriceSearchResponseDTO response = completedDealService.searchMarketPrice(requestDTO, pageable);
 

--- a/src/main/java/com/ani/taku_backend/marketprice/controller/CompletedDealController.java
+++ b/src/main/java/com/ani/taku_backend/marketprice/controller/CompletedDealController.java
@@ -6,11 +6,13 @@ import com.ani.taku_backend.marketprice.model.dto.MarketPriceSearchResponseDTO;
 import com.ani.taku_backend.marketprice.model.dto.PriceGraphRequestDTO;
 import com.ani.taku_backend.marketprice.service.CompletedDealService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
+import org.springframework.data.domain.Sort;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
@@ -28,19 +30,39 @@ public class CompletedDealController {
     @Operation(summary = "시세 조회", description = "키워드로 상품 시세를 조회합니다.")
     @GetMapping("/search")
     public CommonResponse<MarketPriceSearchResponseDTO> searchMarketPrice(
+            @Parameter(description = "검색 키워드", required = true)
             @RequestParam String keyword,
+
+            @Parameter(description = "시작 날짜 (yyyy-MM-dd)", required = true)
             @RequestParam String startDate,
+
+            @Parameter(description = "종료 날짜 (yyyy-MM-dd)", required = true)
             @RequestParam String endDate,
-            @RequestParam(required = false, defaultValue = "ALL") GraphDisplayOption displayOption,
-            @PageableDefault(size = 5) Pageable pageable
+
+            @Parameter(description = "그래프 표시 옵션 (기본값: ALL)", required = false)
+            @RequestParam(defaultValue = "ALL") GraphDisplayOption displayOption,
+
+            @Parameter(description = "요청할 페이지 번호 (기본값: 0)", example = "0", required = false)
+            @RequestParam(defaultValue = "0") int page, // 페이지 번호
+
+            @Parameter(description = "한 페이지당 데이터 개수 (기본값: 5)", example = "5", required = false)
+            @RequestParam(defaultValue = "5") int size, // 페이지 크기
+
+            @Parameter(description = "정렬 조건 (기본값: id,asc)", example = "id,asc", required = false)
+            @RequestParam(defaultValue = "id,asc") String sort // 정렬 조건
     ) {
         try {
-            log.debug("시세 조회 요청 - keyword: {}, startDate: {}, endDate: {}, displayOption: {}, pageable: {}",
-                    keyword, startDate, endDate, displayOption, pageable);
+            log.debug("시세 조회 요청 - keyword: {}, startDate: {}, endDate: {}, displayOption: {}, page: {}, size: {}, sort: {}",
+                    keyword, startDate, endDate, displayOption, page, size, sort);
 
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
             LocalDate parsedStartDate = LocalDate.parse(startDate, formatter);
             LocalDate parsedEndDate = LocalDate.parse(endDate, formatter);
+
+
+            String[] sortParams = sort.split(",");
+            Sort.Direction direction = Sort.Direction.fromString(sortParams[1]);
+            Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortParams[0]));
 
             var requestDTO = new PriceGraphRequestDTO(keyword, parsedStartDate, parsedEndDate, displayOption);
 

--- a/src/main/java/com/ani/taku_backend/marketprice/model/dto/MarketPriceSearchResponseDTO.java
+++ b/src/main/java/com/ani/taku_backend/marketprice/model/dto/MarketPriceSearchResponseDTO.java
@@ -1,15 +1,14 @@
 package com.ani.taku_backend.marketprice.model.dto;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
+@Builder
+@Schema(description = "시세 검색 응답 DTO")
 public class MarketPriceSearchResponseDTO {
 
     @Schema(description = "검색 키워드", example = "원피스 루피 피규어")
@@ -24,13 +23,11 @@ public class MarketPriceSearchResponseDTO {
     @Schema(description = "유사 상품 목록")
     private final List<SimilarProductResponseDTO> similarProducts;
 
-    @JsonCreator
-    @Builder
     public MarketPriceSearchResponseDTO(
-            @JsonProperty("keyword") String keyword,
-            @JsonProperty("priceGraph") PriceGraphResponseDTO priceGraph,
-            @JsonProperty("weeklyStats") WeeklyStatsResponseDTO weeklyStats,
-            @JsonProperty("similarProducts") List<SimilarProductResponseDTO> similarProducts
+            String keyword,
+            PriceGraphResponseDTO priceGraph,
+            WeeklyStatsResponseDTO weeklyStats,
+            List<SimilarProductResponseDTO> similarProducts
     ) {
         this.keyword = keyword;
         this.priceGraph = priceGraph;

--- a/src/main/java/com/ani/taku_backend/marketprice/model/dto/MarketPriceSearchResponseDTO.java
+++ b/src/main/java/com/ani/taku_backend/marketprice/model/dto/MarketPriceSearchResponseDTO.java
@@ -1,6 +1,5 @@
 package com.ani.taku_backend.marketprice.model.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.Builder;

--- a/src/main/java/com/ani/taku_backend/marketprice/model/dto/PriceGraphRequestDTO.java
+++ b/src/main/java/com/ani/taku_backend/marketprice/model/dto/PriceGraphRequestDTO.java
@@ -1,7 +1,7 @@
 package com.ani.taku_backend.marketprice.model.dto;
 
 import com.ani.taku_backend.marketprice.model.constant.GraphDisplayOption;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import java.time.LocalDate;
 import lombok.AllArgsConstructor;
@@ -16,18 +16,22 @@ import org.springframework.format.annotation.DateTimeFormat;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
+@Schema(description = "시세 그래프 요청 DTO")
 public class PriceGraphRequestDTO {
 
+    @Schema(description = "검색 키워드", example = "원피스 루피 피규어")
     @NotBlank(message = "키워드는 필수입니다")
     private String keyword;
 
+    @Schema(description = "조회 시작일", example = "2024-01-01")
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate fromDate;
 
+    @Schema(description = "조회 종료일", example = "2024-01-31")
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate toDate;
 
+    @Schema(description = "그래프 표시 옵션", example = "ALL")
     private GraphDisplayOption displayOption;
 
     @Override

--- a/src/main/java/com/ani/taku_backend/marketprice/model/dto/PriceGraphResponseDTO.java
+++ b/src/main/java/com/ani/taku_backend/marketprice/model/dto/PriceGraphResponseDTO.java
@@ -37,12 +37,26 @@ public class PriceGraphResponseDTO {
     @Getter
     @Builder
     @JsonDeserialize(builder = PriceDataPoint.PriceDataPointBuilder.class)
+    @Schema(description = "시세 데이터 포인트")
     public static class PriceDataPoint {
 
-        private final LocalDate date;            // 날짜
-        private final BigDecimal registeredPrice; // 등록 가격
-        private final BigDecimal soldPrice;       // 판매 가격
-        private final int dealCount;             // 거래 건수
+        @Schema(description = "날짜")
+        private final LocalDate date;
+
+        @Schema(description = "상품 ID")
+        private final Long productId;
+
+        @Schema(description = "상품 제목")
+        private final String title;
+
+        @Schema(description = "등록 가격")
+        private final BigDecimal registeredPrice;
+
+        @Schema(description = "판매 가격")
+        private final BigDecimal soldPrice;
+
+        @Schema(description = "거래 건수")
+        private final int dealCount;
 
         @JsonPOJOBuilder(withPrefix = "")
         public static class PriceDataPointBuilder {

--- a/src/main/java/com/ani/taku_backend/marketprice/model/dto/PriceGraphResponseDTO.java
+++ b/src/main/java/com/ani/taku_backend/marketprice/model/dto/PriceGraphResponseDTO.java
@@ -1,8 +1,5 @@
 package com.ani.taku_backend.marketprice.model.dto;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -11,13 +8,8 @@ import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 
-/**
- * 시세 그래프 응답 DTO
- */
 @Getter
 @Builder
-@JsonDeserialize(builder = PriceGraphResponseDTO.PriceGraphResponseDTOBuilder.class)
-@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
 @Schema(description = "시세 그래프 응답 DTO")
 public class PriceGraphResponseDTO {
 
@@ -30,36 +22,27 @@ public class PriceGraphResponseDTO {
                 .build();
     }
 
-    @JsonPOJOBuilder(withPrefix = "")
-    public static class PriceGraphResponseDTOBuilder {
-    }
-
     @Getter
     @Builder
-    @JsonDeserialize(builder = PriceDataPoint.PriceDataPointBuilder.class)
     @Schema(description = "시세 데이터 포인트")
     public static class PriceDataPoint {
 
-        @Schema(description = "날짜")
+        @Schema(description = "날짜", example = "2024-01-01")
         private final LocalDate date;
 
-        @Schema(description = "상품 ID")
+        @Schema(description = "상품 ID", example = "1")
         private final Long productId;
 
-        @Schema(description = "상품 제목")
+        @Schema(description = "상품 제목", example = "원피스 루피 피규어")
         private final String title;
 
-        @Schema(description = "등록 가격")
+        @Schema(description = "등록 가격", example = "50000")
         private final BigDecimal registeredPrice;
 
-        @Schema(description = "판매 가격")
+        @Schema(description = "판매 가격", example = "45000")
         private final BigDecimal soldPrice;
 
-        @Schema(description = "거래 건수")
+        @Schema(description = "거래 건수", example = "3")
         private final int dealCount;
-
-        @JsonPOJOBuilder(withPrefix = "")
-        public static class PriceDataPointBuilder {
-        }
     }
 }

--- a/src/main/java/com/ani/taku_backend/marketprice/model/dto/SimilarProductResponseDTO.java
+++ b/src/main/java/com/ani/taku_backend/marketprice/model/dto/SimilarProductResponseDTO.java
@@ -2,21 +2,16 @@ package com.ani.taku_backend.marketprice.model.dto;
 
 import com.ani.taku_backend.jangter.model.entity.DuckuJangter;
 import com.ani.taku_backend.marketprice.util.batch.TfidfService;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.List;
+import lombok.Builder;
 import lombok.Getter;
 
-/**
- * 유사 상품 정보 DTO
- */
 @Getter
+@Builder
 @Schema(description = "유사 상품 정보 DTO")
-@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
 public class SimilarProductResponseDTO {
 
     @Schema(description = "상품 ID", example = "123")
@@ -28,62 +23,55 @@ public class SimilarProductResponseDTO {
     @Schema(description = "등록 가격", example = "21000")
     private final BigDecimal price;
 
-    @Schema(description = "TF-IDF 벡터 값(예시)", example = "JSON 형태 String 등")
+    @Schema(description = "TF-IDF 벡터 값", example = "0.5,0.3,0.2")
     private final String tfidfVector;
 
-    @Schema(description = "대표 썸네일 (단일 이미지 URL)")
-    private final List<String> imageUrls;
+    @Schema(description = "대표 썸네일 URL", example = "https://example.com/image.jpg")
+    private final String imageUrl;
 
-    @JsonCreator
+    @Builder
     public SimilarProductResponseDTO(
-            @JsonProperty("productId") Long productId,
-            @JsonProperty("title") String title,
-            @JsonProperty("price") BigDecimal price,
-            @JsonProperty("tfidfVector") String tfidfVector,
-            @JsonProperty("imageUrl") String imageUrl
+            Long productId,
+            String title,
+            BigDecimal price,
+            String tfidfVector,
+            String imageUrl
     ) {
         this.productId = productId;
         this.title = title;
         this.price = price;
         this.tfidfVector = tfidfVector;
-
-        if (imageUrl != null) {
-            this.imageUrls = Collections.singletonList(imageUrl);
-        } else {
-            this.imageUrls = Collections.emptyList();
-        }
+        this.imageUrl = imageUrl;
     }
 
     public static SimilarProductResponseDTO from(DuckuJangter product) {
-        // 썸네일을 대표 이미지 1장만 뽑는다. 수정 가능성 존재
         String singleImageUrl = product.getJangterImages().stream()
                 .findFirst()
                 .map(img -> img.getImage().getImageUrl())
                 .orElse(null);
 
-        return new SimilarProductResponseDTO(
-                product.getId(),
-                product.getTitle(),
-                product.getPrice(),
-                product.getTfidfVector(),   // String 형태로 가정
-                singleImageUrl
-        );
+        return SimilarProductResponseDTO.builder()
+                .productId(product.getId())
+                .title(product.getTitle())
+                .price(product.getPrice())
+                .tfidfVector(product.getTfidfVector())
+                .imageUrl(singleImageUrl)
+                .build();
     }
 
     public static SimilarProductResponseDTO from(TfidfService.ProductWithSimilarity productWithSimilarity) {
         DuckuJangter product = productWithSimilarity.getProduct();
-
         String singleImageUrl = product.getJangterImages().stream()
                 .findFirst()
                 .map(img -> img.getImage().getImageUrl())
                 .orElse(null);
 
-        return new SimilarProductResponseDTO(
-                product.getId(),
-                product.getTitle(),
-                product.getPrice(),
-                product.getTfidfVector(),
-                singleImageUrl
-        );
+        return SimilarProductResponseDTO.builder()
+                .productId(product.getId())
+                .title(product.getTitle())
+                .price(product.getPrice())
+                .tfidfVector(product.getTfidfVector())
+                .imageUrl(singleImageUrl)
+                .build();
     }
 }

--- a/src/main/java/com/ani/taku_backend/marketprice/model/dto/SimilarProductResponseDTO.java
+++ b/src/main/java/com/ani/taku_backend/marketprice/model/dto/SimilarProductResponseDTO.java
@@ -4,8 +4,6 @@ import com.ani.taku_backend.jangter.model.entity.DuckuJangter;
 import com.ani.taku_backend.marketprice.util.batch.TfidfService;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
-import java.util.Collections;
-import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/src/main/java/com/ani/taku_backend/marketprice/model/dto/WeeklyStatsResponseDTO.java
+++ b/src/main/java/com/ani/taku_backend/marketprice/model/dto/WeeklyStatsResponseDTO.java
@@ -1,20 +1,12 @@
 package com.ani.taku_backend.marketprice.model.dto;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
 import lombok.Builder;
 import lombok.Getter;
 
-/**
- * 최근 일주일 판매 통계 DTO
- */
 @Getter
 @Builder
-@JsonDeserialize(builder = WeeklyStatsResponseDTO.WeeklyStatsResponseDTOBuilder.class)
-@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
 @Schema(description = "최근 일주일 판매 통계 DTO")
 public class WeeklyStatsResponseDTO {
 
@@ -30,13 +22,22 @@ public class WeeklyStatsResponseDTO {
     @Schema(description = "거래 건수", example = "42")
     private final long totalDeals;
 
-    public WeeklyStatsResponseDTO(Double avg, BigDecimal max, BigDecimal min, Long count) {
-        this(
-                (avg != null) ? BigDecimal.valueOf(avg) : BigDecimal.ZERO, // averagePrice
-                (max != null) ? max : BigDecimal.ZERO,                     // highestPrice
-                (min != null) ? min : BigDecimal.ZERO,                     // lowestPrice
-                (count != null) ? count : 0L                               // totalDeals
-        );
+
+    public WeeklyStatsResponseDTO(Double averagePrice, BigDecimal highestPrice,
+                                  BigDecimal lowestPrice, Long totalDeals) {
+        this.averagePrice = averagePrice != null ? BigDecimal.valueOf(averagePrice) : BigDecimal.ZERO;
+        this.highestPrice = highestPrice != null ? highestPrice : BigDecimal.ZERO;
+        this.lowestPrice = lowestPrice != null ? lowestPrice : BigDecimal.ZERO;
+        this.totalDeals = totalDeals != null ? totalDeals : 0L;
+    }
+
+    @Builder
+    public WeeklyStatsResponseDTO(BigDecimal averagePrice, BigDecimal highestPrice,
+                                  BigDecimal lowestPrice, long totalDeals) {
+        this.averagePrice = averagePrice != null ? averagePrice : BigDecimal.ZERO;
+        this.highestPrice = highestPrice != null ? highestPrice : BigDecimal.ZERO;
+        this.lowestPrice = lowestPrice != null ? lowestPrice : BigDecimal.ZERO;
+        this.totalDeals = totalDeals;
     }
 
     public static WeeklyStatsResponseDTO empty() {
@@ -46,32 +47,5 @@ public class WeeklyStatsResponseDTO {
                 .lowestPrice(BigDecimal.ZERO)
                 .totalDeals(0L)
                 .build();
-    }
-
-    @JsonPOJOBuilder(withPrefix = "")
-    public static class WeeklyStatsResponseDTOBuilder {
-
-        public WeeklyStatsResponseDTO build() {
-            BigDecimal finalAvgPrice = (averagePrice == null) ? BigDecimal.ZERO : averagePrice;
-
-            return new WeeklyStatsResponseDTO(
-                    finalAvgPrice,
-                    (highestPrice == null) ? BigDecimal.ZERO : highestPrice,
-                    (lowestPrice == null) ? BigDecimal.ZERO : lowestPrice,
-                    totalDeals
-            );
-        }
-    }
-
-    private WeeklyStatsResponseDTO(
-            BigDecimal averagePrice,
-            BigDecimal highestPrice,
-            BigDecimal lowestPrice,
-            long totalDeals
-    ) {
-        this.averagePrice = averagePrice;
-        this.highestPrice = highestPrice;
-        this.lowestPrice = lowestPrice;
-        this.totalDeals = totalDeals;
     }
 }

--- a/src/main/java/com/ani/taku_backend/marketprice/model/entity/MarketPriceStats.java
+++ b/src/main/java/com/ani/taku_backend/marketprice/model/entity/MarketPriceStats.java
@@ -35,7 +35,6 @@ public class MarketPriceStats extends BaseTimeEntity {
     @JoinColumn(name = "product_id")
     private DuckuJangter product;
 
-
     @NotNull
     @Column(length = 255, nullable = false)
     private String title;


### PR DESCRIPTION
Title
[ 시세 그래프 응답 DTO] datapoints에 상품 id와 title까지 함께 전달

## Description
- 프론트 담당자분 요청으로  시세 그래프 응답 DTO 내부 datapoints에 상품 id와 title까지 함께 전달하도록 추가하였습니다.
- Swagger에서 JSON 형태로 출력되던 문제를 해결하고, **블록 형태(Query Parameter 방식)**로 보이도록 수정하였습니다. 

## Changes
- datapoints에 상품 id와 title이 추가됐습니다. (class PriceGraphResponseDTO)
- Query Parameter로 페이징 처리:
기존 Pageable 객체를 사용하지 않고, page, size, sort를 개별 Query Parameter로 분리 처리.@RequestParam으로 page(페이지 번호), size(페이지 크기), sort(정렬 조건)를 수동으로 받아 Pageable 객체를 직접 생성했습니다.

## Screenshots
![image](https://github.com/user-attachments/assets/a51b5056-eadb-4e01-b042-e43d753a5e45)


## Ref

