### PR TITLE
 [Chat] 채팅방 안 읽은 메시지 수 조회 기능 구현

### DIFF
--- a/src/main/java/com/ani/taku_backend/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/controller/ChatRoomController.java
@@ -30,4 +30,12 @@ public class ChatRoomController {
         List<ChatRoomResponseDTO> chatRooms = chatRoomService.findChatRoomList(userId);
         return CommonResponse.ok(chatRooms);
     }
+
+    @GetMapping("/{roomId}")
+    public CommonResponse<ChatRoomResponseDTO> getChatRoom(
+            @PathVariable String roomId,
+            @RequestParam Long userId) {
+        ChatRoomResponseDTO chatRoom = chatRoomService.findChatRoom(roomId, userId);
+        return CommonResponse.ok(chatRoom);
+    }
 }

--- a/src/main/java/com/ani/taku_backend/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/controller/ChatRoomController.java
@@ -42,14 +42,14 @@ public class ChatRoomController {
     @GetMapping("/{roomId}/unread")
     public CommonResponse<Integer> getChatRoomUnreadCount(
             @PathVariable String roomId,
-            @RequestParam String userId) {
+            @RequestParam Long userId) {
         Integer unreadCount = chatRoomService.getChatRoomUnreadCount(roomId, userId);
         return CommonResponse.ok(unreadCount);
     }
 
     @GetMapping("/unread/total")
     public CommonResponse<Integer> getTotalUnreadCount(
-            @RequestParam String userId) {
+            @RequestParam Long userId) {
         Integer totalUnreadCount = chatRoomService.getTotalUnreadCount(userId);
         return CommonResponse.ok(totalUnreadCount);
     }

--- a/src/main/java/com/ani/taku_backend/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/controller/ChatRoomController.java
@@ -38,4 +38,19 @@ public class ChatRoomController {
         ChatRoomResponseDTO chatRoom = chatRoomService.findChatRoom(roomId, userId);
         return CommonResponse.ok(chatRoom);
     }
+
+    @GetMapping("/{roomId}/unread")
+    public CommonResponse<Integer> getChatRoomUnreadCount(
+            @PathVariable String roomId,
+            @RequestParam String userId) {
+        Integer unreadCount = chatRoomService.getChatRoomUnreadCount(roomId, userId);
+        return CommonResponse.ok(unreadCount);
+    }
+
+    @GetMapping("/unread/total")
+    public CommonResponse<Integer> getTotalUnreadCount(
+            @RequestParam String userId) {
+        Integer totalUnreadCount = chatRoomService.getTotalUnreadCount(userId);
+        return CommonResponse.ok(totalUnreadCount);
+    }
 }

--- a/src/main/java/com/ani/taku_backend/chatroom/model/document/ChatroomMetaInfo.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/model/document/ChatroomMetaInfo.java
@@ -1,0 +1,29 @@
+package com.ani.taku_backend.chatroom.model.document;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.annotation.Id;
+import java.time.Instant;
+
+@Document(collection = "chat_room_meta")
+@Getter
+public class ChatroomMetaInfo {
+    @Id
+    private String chatroomId;
+    private Participants participants;
+    private String lastMessage;
+    private Instant updateAt;
+
+    @Builder
+    public ChatroomMetaInfo(String chatroomId) {
+        this.chatroomId = chatroomId;
+        this.participants = new Participants();
+        this.updateAt = Instant.now();
+    }
+
+    public void initializeParticipants(Long buyerId, Long sellerId) {
+        this.participants.addParticipant(buyerId.toString());
+        this.participants.addParticipant(sellerId.toString());
+    }
+}

--- a/src/main/java/com/ani/taku_backend/chatroom/model/document/ParticipantInfo.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/model/document/ParticipantInfo.java
@@ -1,0 +1,19 @@
+package com.ani.taku_backend.chatroom.model.document;
+
+import lombok.Getter;
+import java.time.Instant;
+
+@Getter
+public class ParticipantInfo {
+    private String userId;
+    private Boolean isConnected;
+    private Integer messageStock;
+    private Instant lastDisconnectedAt;
+
+    public ParticipantInfo(String userId) {
+        this.userId = userId;
+        this.isConnected = false;
+        this.messageStock = 0;
+        this.lastDisconnectedAt = Instant.now();
+    }
+}

--- a/src/main/java/com/ani/taku_backend/chatroom/model/document/ParticipantInfo.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/model/document/ParticipantInfo.java
@@ -16,4 +16,12 @@ public class ParticipantInfo {
         this.messageStock = 0;
         this.lastDisconnectedAt = Instant.now();
     }
+
+    public void plusMessage() {
+        this.messageStock++;
+    }
+
+    public void resetMessageStock() {
+        this.messageStock = 0;
+    }
 }

--- a/src/main/java/com/ani/taku_backend/chatroom/model/document/Participants.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/model/document/Participants.java
@@ -1,0 +1,14 @@
+package com.ani.taku_backend.chatroom.model.document;
+
+import lombok.Getter;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.Map;
+
+@Getter
+public class Participants {
+    private Map<String, ParticipantInfo> info = new ConcurrentHashMap<>();
+
+    public void addParticipant(String userId) {
+        info.put(userId, new ParticipantInfo(userId));
+    }
+}

--- a/src/main/java/com/ani/taku_backend/chatroom/model/document/Participants.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/model/document/Participants.java
@@ -11,4 +11,12 @@ public class Participants {
     public void addParticipant(String userId) {
         info.put(userId, new ParticipantInfo(userId));
     }
+
+    public synchronized void updateMessageStock(String userId, boolean increase) {
+        ParticipantInfo info = this.info.get(userId);
+        if (info != null) {
+            if (increase) info.plusMessage();
+            else info.resetMessageStock();
+        }
+    }
 }

--- a/src/main/java/com/ani/taku_backend/chatroom/model/dto/ChatRoomRequestDTO.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/model/dto/ChatRoomRequestDTO.java
@@ -1,28 +1,20 @@
 package com.ani.taku_backend.chatroom.model.dto;
 
 import jakarta.validation.constraints.NotNull;
-import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ChatRoomRequestDTO {
+public record ChatRoomRequestDTO(
+        @NotNull(message = "상품 ID는 필수입니다.")
+        Long articleId,
 
-    @NotNull(message = "상품 ID는 필수입니다.")
-    private Long articleId;
+        @NotNull(message = "구매자 ID는 필수입니다.")
+        Long buyerId,
 
-    @NotNull(message = "구매자 ID는 필수입니다.")
-    private Long buyerId;
-
-    @NotNull(message = "판매자 ID는 필수입니다.")
-    private Long sellerId;
-
+        @NotNull(message = "판매자 ID는 필수입니다.")
+        Long sellerId
+) {
     @Builder
-    public ChatRoomRequestDTO(Long articleId, Long buyerId, Long sellerId) {
-        this.articleId = articleId;
-        this.buyerId = buyerId;
-        this.sellerId = sellerId;
+    public ChatRoomRequestDTO {
+        // validation추가
     }
 }

--- a/src/main/java/com/ani/taku_backend/chatroom/model/dto/ChatRoomResponseDTO.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/model/dto/ChatRoomResponseDTO.java
@@ -2,34 +2,22 @@ package com.ani.taku_backend.chatroom.model.dto;
 
 import com.ani.taku_backend.chatroom.model.entity.ChatRoom;
 import java.time.LocalDateTime;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 
-@Getter
-@AllArgsConstructor
-public class ChatRoomResponseDTO {
-    private Long id;
-    private String roomId;
-    private Long articleId;
-    private Long buyerId;
-    private Long sellerId;
-    private Long lastMessageId;
-    private Long unreadCount;
-    private LocalDateTime createdAt;
-
-    public static ChatRoomResponseDTO of(ChatRoom chatRoom, Long userId) {
-        long unreadCount = userId.equals(chatRoom.getBuyerId())
-                ? chatRoom.getLastMessageId() - chatRoom.getBuyerLastReadMessageId()
-                : chatRoom.getLastMessageId() - chatRoom.getSellerLastReadMessageId();
-
+public record ChatRoomResponseDTO(
+        Long id,
+        String roomId,
+        Long articleId,
+        Long buyerId,
+        Long sellerId,
+        LocalDateTime createdAt
+) {
+    public static ChatRoomResponseDTO of(ChatRoom chatRoom) {
         return new ChatRoomResponseDTO(
                 chatRoom.getId(),
                 chatRoom.getRoomId(),
                 chatRoom.getArticleId(),
                 chatRoom.getBuyerId(),
                 chatRoom.getSellerId(),
-                chatRoom.getLastMessageId(),
-                Math.max(0, unreadCount),   //TODO 읽음 업데이트 구현 시 삭제
                 chatRoom.getCreatedAt()
         );
     }

--- a/src/main/java/com/ani/taku_backend/chatroom/model/dto/ChatRoomResponseDTO.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/model/dto/ChatRoomResponseDTO.java
@@ -29,7 +29,7 @@ public class ChatRoomResponseDTO {
                 chatRoom.getBuyerId(),
                 chatRoom.getSellerId(),
                 chatRoom.getLastMessageId(),
-                Math.max(0, unreadCount),
+                Math.max(0, unreadCount),   //TODO 읽음 업데이트 구현 시 삭제
                 chatRoom.getCreatedAt()
         );
     }

--- a/src/main/java/com/ani/taku_backend/chatroom/model/entity/ChatRoom.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/model/entity/ChatRoom.java
@@ -38,15 +38,6 @@ public class ChatRoom extends BaseTimeEntity {
     @Column(name = "seller_id", nullable = false)
     private Long sellerId;
 
-    @Column(name = "last_message_id")
-    private Long lastMessageId = 0L;
-
-    @Column(name = "buyer_last_read_message_id")
-    private Long buyerLastReadMessageId = 0L;
-
-    @Column(name = "seller_last_read_message_id")
-    private Long sellerLastReadMessageId = 0L;
-
     @Enumerated(EnumType.STRING)
     @Column(name = "status")
     private ChatRoomStatus status = ChatRoomStatus.ACTIVE;
@@ -57,18 +48,6 @@ public class ChatRoom extends BaseTimeEntity {
         this.articleId = articleId;
         this.buyerId = buyerId;
         this.sellerId = sellerId;
-    }
-
-    public void updateLastMessage(Long messageId) {
-        this.lastMessageId = messageId;
-    }
-
-    public void updateBuyerLastRead(Long messageId) {
-        this.buyerLastReadMessageId = messageId;
-    }
-
-    public void updateSellerLastRead(Long messageId) {
-        this.sellerLastReadMessageId = messageId;
     }
 
     public void deactivate() {

--- a/src/main/java/com/ani/taku_backend/chatroom/repository/ChatroomMetaRepository.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/repository/ChatroomMetaRepository.java
@@ -1,0 +1,12 @@
+
+package com.ani.taku_backend.chatroom.repository;
+
+import com.ani.taku_backend.chatroom.model.document.ChatroomMetaInfo;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+import java.util.List;
+
+@Repository
+public interface ChatroomMetaRepository extends MongoRepository<ChatroomMetaInfo, String> {
+    List<ChatroomMetaInfo> findByParticipantsInfoUserIdOrderByUpdateAtDesc(String userId);
+}

--- a/src/main/java/com/ani/taku_backend/chatroom/repository/ChatroomMetaRepository.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/repository/ChatroomMetaRepository.java
@@ -3,10 +3,12 @@ package com.ani.taku_backend.chatroom.repository;
 
 import com.ani.taku_backend.chatroom.model.document.ChatroomMetaInfo;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
 public interface ChatroomMetaRepository extends MongoRepository<ChatroomMetaInfo, String> {
-    List<ChatroomMetaInfo> findAllByUserIdOrderByUpdateAtDesc(String userId);
+    @Query("{ 'participants.info.?0': { $exists: true } }")
+    List<ChatroomMetaInfo> findByParticipantIdOrderByUpdateAtDesc(String userId);
 }

--- a/src/main/java/com/ani/taku_backend/chatroom/repository/ChatroomMetaRepository.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/repository/ChatroomMetaRepository.java
@@ -8,5 +8,5 @@ import java.util.List;
 
 @Repository
 public interface ChatroomMetaRepository extends MongoRepository<ChatroomMetaInfo, String> {
-    List<ChatroomMetaInfo> findByParticipantsInfoUserIdOrderByUpdateAtDesc(String userId);
+    List<ChatroomMetaInfo> findAllByUserIdOrderByUpdateAtDesc(String userId);
 }

--- a/src/main/java/com/ani/taku_backend/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/service/ChatRoomService.java
@@ -58,4 +58,15 @@ public class ChatRoomService {
             throw new DuckwhoException(ErrorCode.DUPLICATE_CHAT_ROOM);
         }
     }
+
+    public ChatRoomResponseDTO findChatRoom(String roomId, Long userId) {
+        ChatRoom chatRoom = chatRoomRepository.findByRoomId(roomId)
+                .orElseThrow(() -> new DuckwhoException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        if (!chatRoom.getBuyerId().equals(userId) && !chatRoom.getSellerId().equals(userId)) {
+            throw new DuckwhoException(ErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        return ChatRoomResponseDTO.of(chatRoom, userId);
+    }
 }

--- a/src/main/java/com/ani/taku_backend/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/service/ChatRoomService.java
@@ -82,7 +82,7 @@ public class ChatRoomService {
         return ChatRoomResponseDTO.of(chatRoom);
     }
 
-    public Integer getChatRoomUnreadCount(String roomId, Long userId) {  // String -> Long
+    public Integer getChatRoomUnreadCount(String roomId, Long userId) {
         ChatroomMetaInfo metaInfo = chatroomMetaRepository.findById(roomId)
                 .orElseThrow(() -> new DuckwhoException(ErrorCode.CHAT_ROOM_NOT_FOUND));
 
@@ -94,9 +94,9 @@ public class ChatRoomService {
         return participantInfo.getMessageStock();
     }
 
-    public Integer getTotalUnreadCount(Long userId) {  // String -> Long
+    public Integer getTotalUnreadCount(Long userId) {
         List<ChatroomMetaInfo> userChatrooms = chatroomMetaRepository
-                .findAllByUserIdOrderByUpdateAtDesc(userId.toString());
+                .findByParticipantIdOrderByUpdateAtDesc(userId.toString());
 
         return userChatrooms.stream()
                 .map(chatroom -> {

--- a/src/main/java/com/ani/taku_backend/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/service/ChatRoomService.java
@@ -30,13 +30,21 @@ public class ChatRoomService {
         validateNewChatRoom(requestDto);
 
         ChatRoom chatRoom = ChatRoom.builder()
-                .articleId(requestDto.getArticleId())
-                .buyerId(requestDto.getBuyerId())
-                .sellerId(requestDto.getSellerId())
+                .articleId(requestDto.articleId())
+                .buyerId(requestDto.buyerId())
+                .sellerId(requestDto.sellerId())
                 .build();
 
         ChatRoom savedRoom = chatRoomRepository.save(chatRoom);
-        return ChatRoomResponseDTO.of(savedRoom, requestDto.getBuyerId());
+
+        // 채팅방 메타정보 생성
+        ChatroomMetaInfo metaInfo = ChatroomMetaInfo.builder()
+                .chatroomId(savedRoom.getRoomId())
+                .build();
+        metaInfo.initializeParticipants(requestDto.buyerId(), requestDto.sellerId());
+        chatroomMetaRepository.save(metaInfo);
+
+        return ChatRoomResponseDTO.of(savedRoom);
     }
 
     public List<ChatRoomResponseDTO> findChatRoomList(Long userId) {
@@ -50,15 +58,15 @@ public class ChatRoomService {
         allRooms.addAll(sellerRooms);
 
         return allRooms.stream()
-                .map(room -> ChatRoomResponseDTO.of(room, userId))
+                .map(ChatRoomResponseDTO::of)
                 .collect(Collectors.toList());
     }
 
     private void validateNewChatRoom(ChatRoomRequestDTO requestDto) {
         if (chatRoomRepository.existsByArticleIdAndBuyerIdAndSellerId(
-                requestDto.getArticleId(),
-                requestDto.getBuyerId(),
-                requestDto.getSellerId())) {
+                requestDto.articleId(),
+                requestDto.buyerId(),
+                requestDto.sellerId())) {
             throw new DuckwhoException(ErrorCode.DUPLICATE_CHAT_ROOM);
         }
     }
@@ -71,14 +79,14 @@ public class ChatRoomService {
             throw new DuckwhoException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
 
-        return ChatRoomResponseDTO.of(chatRoom, userId);
+        return ChatRoomResponseDTO.of(chatRoom);
     }
 
-    public Integer getChatRoomUnreadCount(String roomId, String userId) {
+    public Integer getChatRoomUnreadCount(String roomId, Long userId) {  // String -> Long
         ChatroomMetaInfo metaInfo = chatroomMetaRepository.findById(roomId)
                 .orElseThrow(() -> new DuckwhoException(ErrorCode.CHAT_ROOM_NOT_FOUND));
 
-        ParticipantInfo participantInfo = metaInfo.getParticipants().getInfo().get(userId);
+        ParticipantInfo participantInfo = metaInfo.getParticipants().getInfo().get(userId.toString());
         if (participantInfo == null) {
             throw new DuckwhoException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
@@ -86,13 +94,13 @@ public class ChatRoomService {
         return participantInfo.getMessageStock();
     }
 
-    public Integer getTotalUnreadCount(String userId) {
+    public Integer getTotalUnreadCount(Long userId) {  // String -> Long
         List<ChatroomMetaInfo> userChatrooms = chatroomMetaRepository
-                .findByParticipantsInfoUserIdOrderByUpdateAtDesc(userId);
+                .findAllByUserIdOrderByUpdateAtDesc(userId.toString());
 
         return userChatrooms.stream()
                 .map(chatroom -> {
-                    ParticipantInfo participantInfo = chatroom.getParticipants().getInfo().get(userId);
+                    ParticipantInfo participantInfo = chatroom.getParticipants().getInfo().get(userId.toString());
                     return participantInfo != null ? participantInfo.getMessageStock() : 0;
                 })
                 .reduce(0, Integer::sum);

--- a/src/main/java/com/ani/taku_backend/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/service/ChatRoomService.java
@@ -1,10 +1,13 @@
 package com.ani.taku_backend.chatroom.service;
 
 import com.ani.taku_backend.chatroom.model.constant.ChatRoomStatus;
+import com.ani.taku_backend.chatroom.model.document.ChatroomMetaInfo;
+import com.ani.taku_backend.chatroom.model.document.ParticipantInfo;
 import com.ani.taku_backend.chatroom.model.dto.ChatRoomRequestDTO;
 import com.ani.taku_backend.chatroom.model.dto.ChatRoomResponseDTO;
 import com.ani.taku_backend.chatroom.model.entity.ChatRoom;
 import com.ani.taku_backend.chatroom.repository.ChatRoomRepository;
+import com.ani.taku_backend.chatroom.repository.ChatroomMetaRepository;
 import com.ani.taku_backend.common.exception.DuckwhoException;
 import com.ani.taku_backend.common.exception.ErrorCode;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +23,7 @@ import org.springframework.stereotype.Service;
 public class ChatRoomService {
 
     private final ChatRoomRepository chatRoomRepository;
+    private final ChatroomMetaRepository chatroomMetaRepository;
 
     @Transactional
     public ChatRoomResponseDTO createChatRoom(ChatRoomRequestDTO requestDto) {
@@ -68,5 +72,29 @@ public class ChatRoomService {
         }
 
         return ChatRoomResponseDTO.of(chatRoom, userId);
+    }
+
+    public Integer getChatRoomUnreadCount(String roomId, String userId) {
+        ChatroomMetaInfo metaInfo = chatroomMetaRepository.findById(roomId)
+                .orElseThrow(() -> new DuckwhoException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        ParticipantInfo participantInfo = metaInfo.getParticipants().getInfo().get(userId);
+        if (participantInfo == null) {
+            throw new DuckwhoException(ErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        return participantInfo.getMessageStock();
+    }
+
+    public Integer getTotalUnreadCount(String userId) {
+        List<ChatroomMetaInfo> userChatrooms = chatroomMetaRepository
+                .findByParticipantsInfoUserIdOrderByUpdateAtDesc(userId);
+
+        return userChatrooms.stream()
+                .map(chatroom -> {
+                    ParticipantInfo participantInfo = chatroom.getParticipants().getInfo().get(userId);
+                    return participantInfo != null ? participantInfo.getMessageStock() : 0;
+                })
+                .reduce(0, Integer::sum);
     }
 }


### PR DESCRIPTION
# [Chat] 채팅방 안 읽은 메시지 수 조회 기능 구현

## Description
### 1. 이 일이 왜 시작되었는가?
- 채팅방 목록에서 각 채팅방별 안 읽은 메시지 수 표시 필요
- 전체 채팅방의 안 읽은 메시지 총합 표시 필요


### 2. PR의 내용을 이해하기 위한 배경
  - MySQL: 채팅방 기본 정보 (채팅방 ID, 구매자, 판매자 등)
  - MongoDB: 실시간 메타데이터 (안 읽은 메시지 수, 접속 상태 등)
- WebSocket 기본 설정 완료 상태 (메시지 처리는 재은님 파트)

## Changes
### 1. 구현된 내용
- MongoDB 메타데이터 도메인 설계
  - `ChatroomMetaInfo`: 채팅방 메타정보 문서
  - `Participants`: 참가자 정보 관리 (ConcurrentHashMap 사용)
  - `ParticipantInfo`: 개별 참가자 상태 정보

- API 구현
  - 채팅방별 안 읽은 메시지 수: `GET /api/chat/rooms/{roomId}/unread`
  - 전체 안 읽은 메시지 수: `GET /api/chat/rooms/unread/total`

### 2. 데이터 저장소 책임 분리
| 구분 | MySQL(ChatRoom) | MongoDB(ChatroomMetaInfo) |
|---|---|---|
| 저장 목적 | 채팅방의 영구적인 기본 정보 저장 | 실시간으로 자주 변경되는 메타데이터 저장 |
| 저장 정보 | - id (PK)<br>- roomId<br>- articleId<br>- buyerId<br>- sellerId<br>- status<br>- createdAt, updatedAt | - chatroomId<br>- participants<br>&nbsp;&nbsp;- userId<br>&nbsp;&nbsp;- isConnected<br>&nbsp;&nbsp;- messageStock<br>&nbsp;&nbsp;- lastDisconnectedAt<br>- lastMessage<br>- updateAt |

### 3. 향후 추가 작업
- 재은님 파트 구현 완료 후
  - ChatRoom 엔티티에서 읽음 상태 관련 필드 제거
  - ChatRoomResponseDTO에서 unreadCount 관련 로직 제거
  - ChatRoomService의 읽음 처리 관련 로직 제거
등 수정 예정입니다. 