### PR TITLE
 [Chat] 채팅방 응답에 사용자 정보 추가 및 DTO 구조 개선

### DIFF
--- a/src/main/java/com/ani/taku_backend/chatroom/controller/ChatRoomController.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/controller/ChatRoomController.java
@@ -4,12 +4,18 @@ import com.ani.taku_backend.chatroom.model.dto.ChatRoomRequestDTO;
 import com.ani.taku_backend.chatroom.model.dto.ChatRoomResponseDTO;
 import com.ani.taku_backend.chatroom.service.ChatRoomService;
 import com.ani.taku_backend.common.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "Chat Room API", description = "채팅방 관련 API")
 @RestController
 @RequestMapping("/api/chat/rooms")
 @RequiredArgsConstructor
@@ -17,38 +23,73 @@ public class ChatRoomController {
 
     private final ChatRoomService chatRoomService;
 
+    @Operation(summary = "채팅방 생성", description = "새로운 채팅방을 생성합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "채팅방 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "409", description = "이미 존재하는 채팅방")
+    })
     @PostMapping
     public CommonResponse<ChatRoomResponseDTO> createChatRoom(
+            @Parameter(description = "채팅방 생성 정보", required = true)
             @Valid @RequestBody ChatRoomRequestDTO requestDto) {
         ChatRoomResponseDTO responseDto = chatRoomService.createChatRoom(requestDto);
         return CommonResponse.created(responseDto);
     }
 
+    @Operation(summary = "채팅방 목록 조회", description = "사용자의 모든 채팅방 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "채팅방 목록 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
     @GetMapping
     public CommonResponse<List<ChatRoomResponseDTO>> getChatRoomList(
+            @Parameter(description = "사용자 ID", required = true)
             @RequestParam Long userId) {
         List<ChatRoomResponseDTO> chatRooms = chatRoomService.findChatRoomList(userId);
         return CommonResponse.ok(chatRooms);
     }
 
+    @Operation(summary = "특정 채팅방 조회", description = "채팅방 ID로 특정 채팅방을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "채팅방 조회 성공"),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음"),
+            @ApiResponse(responseCode = "404", description = "채팅방을 찾을 수 없음")
+    })
     @GetMapping("/{roomId}")
     public CommonResponse<ChatRoomResponseDTO> getChatRoom(
+            @Parameter(description = "채팅방 ID", required = true)
             @PathVariable String roomId,
+            @Parameter(description = "사용자 ID", required = true)
             @RequestParam Long userId) {
         ChatRoomResponseDTO chatRoom = chatRoomService.findChatRoom(roomId, userId);
         return CommonResponse.ok(chatRoom);
     }
 
+    @Operation(summary = "채팅방 안 읽은 메시지 수 조회", description = "특정 채팅방의 안 읽은 메시지 수를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "안 읽은 메시지 수 조회 성공"),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음"),
+            @ApiResponse(responseCode = "404", description = "채팅방을 찾을 수 없음")
+    })
     @GetMapping("/{roomId}/unread")
     public CommonResponse<Integer> getChatRoomUnreadCount(
+            @Parameter(description = "채팅방 ID", required = true)
             @PathVariable String roomId,
+            @Parameter(description = "사용자 ID", required = true)
             @RequestParam Long userId) {
         Integer unreadCount = chatRoomService.getChatRoomUnreadCount(roomId, userId);
         return CommonResponse.ok(unreadCount);
     }
 
+    @Operation(summary = "전체 안 읽은 메시지 수 조회", description = "사용자의 모든 채팅방의 안 읽은 메시지 총 개수를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "전체 안 읽은 메시지 수 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
     @GetMapping("/unread/total")
     public CommonResponse<Integer> getTotalUnreadCount(
+            @Parameter(description = "사용자 ID", required = true)
             @RequestParam Long userId) {
         Integer totalUnreadCount = chatRoomService.getTotalUnreadCount(userId);
         return CommonResponse.ok(totalUnreadCount);

--- a/src/main/java/com/ani/taku_backend/chatroom/model/constant/ChatRoomLeftBy.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/model/constant/ChatRoomLeftBy.java
@@ -1,0 +1,23 @@
+package com.ani.taku_backend.chatroom.model.constant;
+
+public enum ChatRoomLeftBy {
+    NONE("없음", "아무도 나가지 않았습니다."),
+    BUYER("구매자", "구매자가 채팅방을 나갔습니다."),
+    SELLER("판매자", "판매자가 채팅방을 나갔습니다.");
+
+    private final String status;
+    private final String message;
+
+    ChatRoomLeftBy(String status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+} 

--- a/src/main/java/com/ani/taku_backend/chatroom/model/constant/ChatRoomStatus.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/model/constant/ChatRoomStatus.java
@@ -1,6 +1,5 @@
 package com.ani.taku_backend.chatroom.model.constant;
 
-
 public enum ChatRoomStatus {
     ACTIVE("활성"),
     INACTIVE("비활성");
@@ -13,5 +12,9 @@ public enum ChatRoomStatus {
 
     public String getDescription() {
         return description;
+    }
+
+    public boolean isActive() {
+        return this == ACTIVE;
     }
 }

--- a/src/main/java/com/ani/taku_backend/chatroom/model/dto/ChatRoomRequestDTO.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/model/dto/ChatRoomRequestDTO.java
@@ -15,6 +15,5 @@ public record ChatRoomRequestDTO(
 ) {
     @Builder
     public ChatRoomRequestDTO {
-        // validation추가
     }
 }

--- a/src/main/java/com/ani/taku_backend/chatroom/model/dto/ChatRoomResponseDTO.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/model/dto/ChatRoomResponseDTO.java
@@ -1,21 +1,27 @@
 package com.ani.taku_backend.chatroom.model.dto;
 
-import com.ani.taku_backend.chatroom.model.constant.ChatRoomLeftBy;
 import com.ani.taku_backend.chatroom.model.entity.ChatRoom;
 import com.ani.taku_backend.user.model.entity.User;
 import java.time.LocalDateTime;
 
 public record ChatRoomResponseDTO(
-        Long id,
-        String roomId,
-        Long articleId,
-        ParticipantDTO buyer,
-        ParticipantDTO seller,
-        LocalDateTime createdAt,
-        ChatRoomLeftBy leftBy,
-        String leaveMessage,
-        boolean canSendMessage
+        ChatRoomInfoDTO info,
+        ParticipantsDTO participants,
+        ChatRoomStatusDTO status
 ) {
+
+    public record ChatRoomInfoDTO(
+            Long id,
+            String roomId,
+            Long articleId,
+            LocalDateTime createdAt
+    ) {}
+
+    public record ParticipantsDTO(
+            ParticipantDTO buyer,
+            ParticipantDTO seller
+    ) {}
+
     public record ParticipantDTO(
             Long userId,
             String nickname,
@@ -30,17 +36,32 @@ public record ChatRoomResponseDTO(
         }
     }
 
-    public static ChatRoomResponseDTO of(ChatRoom chatRoom, User buyer, User seller, Long currentUserId) {
+    public record ChatRoomStatusDTO(
+            boolean canSendMessage,
+            String exitMessage
+    ) {}
+
+    public static ChatRoomResponseDTO of(
+            ChatRoom chatRoom,
+            User buyer,
+            User seller,
+            Long currentUserId
+    ) {
         return new ChatRoomResponseDTO(
-                chatRoom.getId(),
-                chatRoom.getRoomId(),
-                chatRoom.getArticleId(),
-                ParticipantDTO.from(buyer),
-                ParticipantDTO.from(seller),
-                chatRoom.getCreatedAt(),
-                chatRoom.getLeftBy(),
-                chatRoom.getExitMessage(),
-                chatRoom.canSendMessage(currentUserId)
+                new ChatRoomInfoDTO(
+                        chatRoom.getId(),
+                        chatRoom.getRoomId(),
+                        chatRoom.getArticleId(),
+                        chatRoom.getCreatedAt()
+                ),
+                new ParticipantsDTO(
+                        ParticipantDTO.from(buyer),
+                        ParticipantDTO.from(seller)
+                ),
+                new ChatRoomStatusDTO(
+                        chatRoom.canSendMessage(currentUserId),
+                        chatRoom.getExitMessage()
+                )
         );
     }
 }

--- a/src/main/java/com/ani/taku_backend/chatroom/model/dto/ChatRoomResponseDTO.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/model/dto/ChatRoomResponseDTO.java
@@ -1,5 +1,6 @@
 package com.ani.taku_backend.chatroom.model.dto;
 
+import com.ani.taku_backend.chatroom.model.constant.ChatRoomLeftBy;
 import com.ani.taku_backend.chatroom.model.entity.ChatRoom;
 import com.ani.taku_backend.user.model.entity.User;
 import java.time.LocalDateTime;
@@ -10,7 +11,10 @@ public record ChatRoomResponseDTO(
         Long articleId,
         ParticipantDTO buyer,
         ParticipantDTO seller,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        ChatRoomLeftBy leftBy,
+        String leaveMessage,
+        boolean canSendMessage
 ) {
     public record ParticipantDTO(
             Long userId,
@@ -26,14 +30,17 @@ public record ChatRoomResponseDTO(
         }
     }
 
-    public static ChatRoomResponseDTO of(ChatRoom chatRoom, User buyer, User seller) {
+    public static ChatRoomResponseDTO of(ChatRoom chatRoom, User buyer, User seller, Long currentUserId) {
         return new ChatRoomResponseDTO(
                 chatRoom.getId(),
                 chatRoom.getRoomId(),
                 chatRoom.getArticleId(),
                 ParticipantDTO.from(buyer),
                 ParticipantDTO.from(seller),
-                chatRoom.getCreatedAt()
+                chatRoom.getCreatedAt(),
+                chatRoom.getLeftBy(),
+                chatRoom.getExitMessage(),
+                chatRoom.canSendMessage(currentUserId)
         );
     }
 }

--- a/src/main/java/com/ani/taku_backend/chatroom/model/dto/ChatRoomResponseDTO.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/model/dto/ChatRoomResponseDTO.java
@@ -1,23 +1,38 @@
 package com.ani.taku_backend.chatroom.model.dto;
 
 import com.ani.taku_backend.chatroom.model.entity.ChatRoom;
+import com.ani.taku_backend.user.model.entity.User;
 import java.time.LocalDateTime;
 
 public record ChatRoomResponseDTO(
         Long id,
         String roomId,
         Long articleId,
-        Long buyerId,
-        Long sellerId,
+        ParticipantDTO buyer,
+        ParticipantDTO seller,
         LocalDateTime createdAt
 ) {
-    public static ChatRoomResponseDTO of(ChatRoom chatRoom) {
+    public record ParticipantDTO(
+            Long userId,
+            String nickname,
+            String profileImg
+    ) {
+        public static ParticipantDTO from(User user) {
+            return new ParticipantDTO(
+                    user.getUserId(),
+                    user.getNickname(),
+                    user.getProfileImg()
+            );
+        }
+    }
+
+    public static ChatRoomResponseDTO of(ChatRoom chatRoom, User buyer, User seller) {
         return new ChatRoomResponseDTO(
                 chatRoom.getId(),
                 chatRoom.getRoomId(),
                 chatRoom.getArticleId(),
-                chatRoom.getBuyerId(),
-                chatRoom.getSellerId(),
+                ParticipantDTO.from(buyer),
+                ParticipantDTO.from(seller),
                 chatRoom.getCreatedAt()
         );
     }

--- a/src/main/java/com/ani/taku_backend/chatroom/model/entity/ChatRoom.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/model/entity/ChatRoom.java
@@ -3,6 +3,7 @@ package com.ani.taku_backend.chatroom.model.entity;
 import com.ani.taku_backend.chatroom.model.constant.ChatRoomStatus;
 import com.ani.taku_backend.chatroom.model.constant.ChatRoomLeftBy;
 import com.ani.taku_backend.common.baseEntity.BaseTimeEntity;
+import com.ani.taku_backend.user.model.entity.User;  // User 엔티티 import 추가
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -10,7 +11,10 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.FetchType;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -38,6 +42,14 @@ public class ChatRoom extends BaseTimeEntity {
 
     @Column(name = "seller_id", nullable = false)
     private Long sellerId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "buyer_id", insertable = false, updatable = false)
+    private User buyer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "seller_id", insertable = false, updatable = false)
+    private User seller;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status")
@@ -89,9 +101,9 @@ public class ChatRoom extends BaseTimeEntity {
         }
         // 채팅방이 비활성화 상태이고, 나간 사람이면 메시지를 보낼 수 없음
         boolean isBuyer = userId.equals(buyerId);
-        return status.isActive() || 
-               (isBuyer && leftBy != ChatRoomLeftBy.BUYER) || 
-               (!isBuyer && leftBy != ChatRoomLeftBy.SELLER);
+        return status.isActive() ||
+                (isBuyer && leftBy != ChatRoomLeftBy.BUYER) ||
+                (!isBuyer && leftBy != ChatRoomLeftBy.SELLER);
     }
 
     /**
@@ -109,7 +121,7 @@ public class ChatRoom extends BaseTimeEntity {
      */
     public boolean hasUserLeft(Long userId) {
         boolean isBuyer = userId.equals(buyerId);
-        return (isBuyer && leftBy == ChatRoomLeftBy.BUYER) || 
-               (!isBuyer && leftBy == ChatRoomLeftBy.SELLER);
+        return (isBuyer && leftBy == ChatRoomLeftBy.BUYER) ||
+                (!isBuyer && leftBy == ChatRoomLeftBy.SELLER);
     }
 }

--- a/src/main/java/com/ani/taku_backend/chatroom/model/entity/ChatRoom.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/model/entity/ChatRoom.java
@@ -1,6 +1,7 @@
 package com.ani.taku_backend.chatroom.model.entity;
 
 import com.ani.taku_backend.chatroom.model.constant.ChatRoomStatus;
+import com.ani.taku_backend.chatroom.model.constant.ChatRoomLeftBy;
 import com.ani.taku_backend.common.baseEntity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -42,6 +43,10 @@ public class ChatRoom extends BaseTimeEntity {
     @Column(name = "status")
     private ChatRoomStatus status = ChatRoomStatus.ACTIVE;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "left_by")
+    private ChatRoomLeftBy leftBy = ChatRoomLeftBy.NONE;
+
     @Builder
     public ChatRoom(Long articleId, Long buyerId, Long sellerId) {
         this.roomId = UUID.randomUUID().toString();
@@ -50,7 +55,61 @@ public class ChatRoom extends BaseTimeEntity {
         this.sellerId = sellerId;
     }
 
-    public void deactivate() {
+    /**
+     * 채팅방을 비활성화하고 나간 사용자를 기록합니다.
+     * @param userId 채팅방을 나가는 사용자의 ID
+     * @throws IllegalArgumentException 채팅방 참여자가 아닌 경우
+     */
+    public void deactivate(Long userId) {
+        if (!isParticipant(userId)) {
+            throw new IllegalArgumentException("채팅방 참여자가 아닙니다.");
+        }
         this.status = ChatRoomStatus.INACTIVE;
+        this.leftBy = userId.equals(buyerId) ? ChatRoomLeftBy.BUYER : ChatRoomLeftBy.SELLER;
+    }
+
+    /**
+     * 주어진 사용자가 채팅방의 참여자(구매자 또는 판매자)인지 확인합니다.
+     * @param userId 확인할 사용자의 ID
+     * @return 채팅방 참여자이면 true, 아니면 false
+     */
+    public boolean isParticipant(Long userId) {
+        return userId.equals(buyerId) || userId.equals(sellerId);
+    }
+
+    /**
+     * 주어진 사용자가 메시지를 보낼 수 있는지 확인합니다.
+     * 채팅방이 활성화 상태이거나, 사용자가 나가지 않은 상태여야 메시지를 보낼 수 있습니다.
+     * @param userId 확인할 사용자의 ID
+     * @return 메시지를 보낼 수 있으면 true, 없으면 false
+     */
+    public boolean canSendMessage(Long userId) {
+        if (!isParticipant(userId)) {
+            return false;
+        }
+        // 채팅방이 비활성화 상태이고, 나간 사람이면 메시지를 보낼 수 없음
+        boolean isBuyer = userId.equals(buyerId);
+        return status.isActive() || 
+               (isBuyer && leftBy != ChatRoomLeftBy.BUYER) || 
+               (!isBuyer && leftBy != ChatRoomLeftBy.SELLER);
+    }
+
+    /**
+     * 채팅방을 나간 사용자에 대한 메시지를 반환합니다.
+     * @return 채팅방 퇴장 메시지 (예: "구매자가 채팅방을 나갔습니다.")
+     */
+    public String getExitMessage() {
+        return leftBy.getMessage();
+    }
+
+    /**
+     * 주어진 사용자가 채팅방을 나갔는지 확인합니다.
+     * @param userId 확인할 사용자의 ID
+     * @return 사용자가 채팅방을 나갔으면 true, 아니면 false
+     */
+    public boolean hasUserLeft(Long userId) {
+        boolean isBuyer = userId.equals(buyerId);
+        return (isBuyer && leftBy == ChatRoomLeftBy.BUYER) || 
+               (!isBuyer && leftBy == ChatRoomLeftBy.SELLER);
     }
 }

--- a/src/main/java/com/ani/taku_backend/chatroom/repository/ChatRoomRepository.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/repository/ChatRoomRepository.java
@@ -1,40 +1,42 @@
 package com.ani.taku_backend.chatroom.repository;
 
-import com.ani.taku_backend.chatroom.model.constant.ChatRoomStatus;
 import com.ani.taku_backend.chatroom.model.entity.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     /**
-     * 특정 구매자의 모든 채팅방 목록을 조회합니다.
-     * 생성일시 기준 내림차순으로 정렬됩니다.
+     * 사용자가 참여한 모든 채팅방과 참여자 정보를 단일 쿼리로 조회합니다.
+     * - 생성일시 기준 내림차순 정렬
      */
-    List<ChatRoom> findByBuyerIdOrderByCreatedAtDesc(Long buyerId);
+    @Query("""
+        SELECT DISTINCT cr FROM ChatRoom cr
+        JOIN FETCH User buyer ON buyer.userId = cr.buyerId
+        JOIN FETCH User seller ON seller.userId = cr.sellerId
+        WHERE cr.buyerId = :userId OR cr.sellerId = :userId
+        ORDER BY cr.createdAt DESC
+        """)
+    List<ChatRoom> findAllByUserIdWithParticipants(@Param("userId") Long userId);
 
     /**
-     * 특정 판매자의 모든 채팅방 목록을 조회합니다.
-     * 생성일시 기준 내림차순으로 정렬됩니다.
+     * 특정 채팅방과 참여자 정보를 단일 쿼리로 조회합니다.
      */
-    List<ChatRoom> findBySellerIdOrderByCreatedAtDesc(Long sellerId);
-
-    /**
-     * 특정 구매자의 활성화된 채팅방 목록을 조회합니다.
-     * 생성일시 기준 내림차순으로 정렬됩니다.
-     */
-    List<ChatRoom> findByStatusAndBuyerIdOrderByCreatedAtDesc(ChatRoomStatus status, Long buyerId);
-
-    /**
-     * 특정 판매자의 활성화된 채팅방 목록을 조회합니다.
-     * 생성일시 기준 내림차순으로 정렬됩니다.
-     */
-    List<ChatRoom> findByStatusAndSellerIdOrderByCreatedAtDesc(ChatRoomStatus status, Long sellerId);
+    @Query("""
+        SELECT cr FROM ChatRoom cr
+        JOIN FETCH User buyer ON buyer.userId = cr.buyerId
+        JOIN FETCH User seller ON seller.userId = cr.sellerId
+        WHERE cr.roomId = :roomId
+        """)
+    Optional<ChatRoom> findByRoomIdWithParticipants(@Param("roomId") String roomId);
 
     /**
      * WebSocket 세션 관리를 위한 roomId로 채팅방을 조회합니다.
+     * 참여자 정보가 필요하지 않은 경우에 사용됩니다.
      */
     Optional<ChatRoom> findByRoomId(String roomId);
 

--- a/src/main/java/com/ani/taku_backend/chatroom/repository/ChatRoomRepository.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/repository/ChatRoomRepository.java
@@ -37,7 +37,10 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     /**
      * WebSocket 세션 관리를 위한 roomId로 채팅방을 조회합니다.
      * 참여자 정보가 필요하지 않은 경우에 사용됩니다.
+     *
+     * @deprecated 현재 미사용. WebSocket 구현 계획 확인 후 삭제 예정
      */
+    @Deprecated(forRemoval = true, since = "2024-02-09")
     Optional<ChatRoom> findByRoomId(String roomId);
 
     /**

--- a/src/main/java/com/ani/taku_backend/chatroom/repository/ChatRoomRepository.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/repository/ChatRoomRepository.java
@@ -10,10 +10,21 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     /**
+     * 특정 구매자의 모든 채팅방 목록을 조회합니다.
+     * 생성일시 기준 내림차순으로 정렬됩니다.
+     */
+    List<ChatRoom> findByBuyerIdOrderByCreatedAtDesc(Long buyerId);
+
+    /**
+     * 특정 판매자의 모든 채팅방 목록을 조회합니다.
+     * 생성일시 기준 내림차순으로 정렬됩니다.
+     */
+    List<ChatRoom> findBySellerIdOrderByCreatedAtDesc(Long sellerId);
+
+    /**
      * 특정 구매자의 활성화된 채팅방 목록을 조회합니다.
      * 생성일시 기준 내림차순으로 정렬됩니다.
      */
-
     List<ChatRoom> findByStatusAndBuyerIdOrderByCreatedAtDesc(ChatRoomStatus status, Long buyerId);
 
     /**

--- a/src/main/java/com/ani/taku_backend/chatroom/repository/ChatroomMetaRepository.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/repository/ChatroomMetaRepository.java
@@ -1,4 +1,3 @@
-
 package com.ani.taku_backend.chatroom.repository;
 
 import com.ani.taku_backend.chatroom.model.document.ChatroomMetaInfo;
@@ -9,6 +8,18 @@ import java.util.List;
 
 @Repository
 public interface ChatroomMetaRepository extends MongoRepository<ChatroomMetaInfo, String> {
-    @Query("{ 'participants.info.?0': { $exists: true } }")
+    /**
+     * 사용자가 참여한 모든 채팅방의 메타 정보를 조회합니다.
+     * 업데이트 시간 기준 내림차순으로 정렬됩니다.
+     */
+    @Query(value = "{ 'participants.info.?0': { $exists: true } }",
+            sort = "{ 'updateAt': -1 }")
     List<ChatroomMetaInfo> findByParticipantIdOrderByUpdateAtDesc(String userId);
+
+    /**
+     * 채팅방 목록에 대한 메타 정보를 일괄 조회합니다.
+     * 여러 채팅방의 메타 정보를 단일 쿼리로 조회하여 N+1 문제를 방지합니다.
+     */
+    @Query("{ '_id': { $in: ?0 } }")
+    List<ChatroomMetaInfo> findAllByRoomIds(List<String> roomIds);
 }

--- a/src/main/java/com/ani/taku_backend/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/service/ChatRoomService.java
@@ -1,6 +1,5 @@
 package com.ani.taku_backend.chatroom.service;
 
-import com.ani.taku_backend.chatroom.model.constant.ChatRoomStatus;
 import com.ani.taku_backend.chatroom.model.document.ChatroomMetaInfo;
 import com.ani.taku_backend.chatroom.model.document.ParticipantInfo;
 import com.ani.taku_backend.chatroom.model.dto.ChatRoomRequestDTO;
@@ -12,13 +11,18 @@ import com.ani.taku_backend.common.exception.DuckwhoException;
 import com.ani.taku_backend.common.exception.ErrorCode;
 import com.ani.taku_backend.user.model.entity.User;
 import com.ani.taku_backend.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
 import org.springframework.transaction.annotation.Transactional;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+/**
+ * 채팅방 관련 비즈니스 로직을 처리하는 서비스
+ * 채팅방의 생성, 조회, 메시지 카운트 관리 등을 담당합니다.
+ */
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -27,10 +31,39 @@ public class ChatRoomService {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatroomMetaRepository chatroomMetaRepository;
     private final UserRepository userRepository;
+    private final EntityManager entityManager;
 
+    /**
+     * 새로운 채팅방을 생성합니다.
+     * 채팅방 생성 시 중복 검증을 수행하고, 채팅방 메타 정보도 함께 초기화합니다.
+     *
+     * @param requestDto 채팅방 생성 요청 정보 (상품ID, 구매자ID, 판매자ID)
+     * @return 생성된 채팅방 정보
+     * @throws DuckwhoException 중복된 채팅방이 존재하거나 사용자를 찾을 수 없는 경우
+     */
     @Transactional
     public ChatRoomResponseDTO createChatRoom(ChatRoomRequestDTO requestDto) {
         validateNewChatRoom(requestDto);
+
+        // 구매자와 판매자 정보를 단일 쿼리로 조회
+        String jpql = """
+        SELECT DISTINCT u FROM User u 
+        WHERE u.userId IN (:buyerId, :sellerId)
+        """;
+        List<User> users = entityManager.createQuery(jpql, User.class)
+                .setParameter("buyerId", requestDto.buyerId())
+                .setParameter("sellerId", requestDto.sellerId())
+                .getResultList();
+
+        Map<Long, User> userMap = users.stream()
+                .collect(Collectors.toMap(User::getUserId, u -> u));
+
+        User buyer = userMap.get(requestDto.buyerId());
+        User seller = userMap.get(requestDto.sellerId());
+
+        if (buyer == null || seller == null) {
+            throw new DuckwhoException(ErrorCode.USER_NOT_FOUND);
+        }
 
         ChatRoom chatRoom = ChatRoom.builder()
                 .articleId(requestDto.articleId())
@@ -40,42 +73,62 @@ public class ChatRoomService {
 
         ChatRoom savedRoom = chatRoomRepository.save(chatRoom);
 
-        // 채팅방 메타정보 생성
         ChatroomMetaInfo metaInfo = ChatroomMetaInfo.builder()
                 .chatroomId(savedRoom.getRoomId())
                 .build();
         metaInfo.initializeParticipants(requestDto.buyerId(), requestDto.sellerId());
         chatroomMetaRepository.save(metaInfo);
 
-        User buyer = userRepository.findById(requestDto.buyerId())
-                .orElseThrow(() -> new DuckwhoException(ErrorCode.USER_NOT_FOUND));
-        User seller = userRepository.findById(requestDto.sellerId())
-                .orElseThrow(() -> new DuckwhoException(ErrorCode.USER_NOT_FOUND));
-
         return ChatRoomResponseDTO.of(savedRoom, buyer, seller, requestDto.buyerId());
     }
 
+    /**
+     * 사용자가 참여한 모든 채팅방 목록을 조회합니다.
+     * 단일 쿼리로 채팅방과 참여자 정보를 조회하여 N+1 문제를 방지합니다.
+     * 메타 정보도 일괄 조회하여 성능을 최적화합니다.
+     *
+     * @param userId 조회할 사용자 ID
+     * @return 사용자가 참여한 채팅방 목록 (메타 정보 포함)
+     * @throws DuckwhoException 사용자 정보를 찾을 수 없는 경우
+     */
     public List<ChatRoomResponseDTO> findChatRoomList(Long userId) {
-        // 구매자 또는 판매자로 참여한 모든 채팅방을 가져옴
-        List<ChatRoom> buyerRooms = chatRoomRepository.findByBuyerIdOrderByCreatedAtDesc(userId);
-        List<ChatRoom> sellerRooms = chatRoomRepository.findBySellerIdOrderByCreatedAtDesc(userId);
+        // 1. 단일 쿼리로 채팅방과 사용자 정보 모두 조회
+        List<ChatRoom> chatRooms = chatRoomRepository.findAllByUserIdWithParticipants(userId);
 
-        List<ChatRoom> allRooms = new ArrayList<>();
-        allRooms.addAll(buyerRooms);
-        allRooms.addAll(sellerRooms);
+        // 2. 메타 정보 일괄 조회 (MongoDB)
+        List<String> roomIds = chatRooms.stream()
+                .map(ChatRoom::getRoomId)
+                .collect(Collectors.toList());
 
-        return allRooms.stream()
-                .filter(chatRoom -> !chatRoom.hasUserLeft(userId)) // 자신이 나간 채팅방은 제외
+        Map<String, ChatroomMetaInfo> metaInfoMap = chatroomMetaRepository.findAllByRoomIds(roomIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        ChatroomMetaInfo::getChatroomId,
+                        metaInfo -> metaInfo,
+                        (existing, replacement) -> existing
+                ));
+
+        // 3. JOIN FETCH로 가져온 정보 사용
+        return chatRooms.stream()
+                .filter(chatRoom -> !chatRoom.hasUserLeft(userId))
                 .map(chatRoom -> {
-                    User buyer = userRepository.findById(chatRoom.getBuyerId())
-                            .orElseThrow(() -> new DuckwhoException(ErrorCode.USER_NOT_FOUND));
-                    User seller = userRepository.findById(chatRoom.getSellerId())
-                            .orElseThrow(() -> new DuckwhoException(ErrorCode.USER_NOT_FOUND));
-                    return ChatRoomResponseDTO.of(chatRoom, buyer, seller, userId);
+                    ChatroomMetaInfo metaInfo = metaInfoMap.get(chatRoom.getRoomId());
+                    return ChatRoomResponseDTO.of(
+                            chatRoom,
+                            chatRoom.getBuyer(),
+                            chatRoom.getSeller(),
+                            userId
+                    );
                 })
                 .collect(Collectors.toList());
     }
-
+    /**
+     * 새로운 채팅방 생성 시 중복 여부를 검증합니다.
+     * 동일한 상품에 대해 동일한 구매자/판매자 간의 채팅방이 이미 존재하는지 확인합니다.
+     *
+     * @param requestDto 채팅방 생성 요청 정보
+     * @throws DuckwhoException 중복된 채팅방이 존재하는 경우
+     */
     private void validateNewChatRoom(ChatRoomRequestDTO requestDto) {
         if (chatRoomRepository.existsByArticleIdAndBuyerIdAndSellerId(
                 requestDto.articleId(),
@@ -85,31 +138,54 @@ public class ChatRoomService {
         }
     }
 
+    /**
+     * 특정 채팅방의 상세 정보를 조회합니다.
+     * 채팅방 존재 여부, 접근 권한, 채팅방 퇴장 여부를 확인합니다.
+     *
+     * @param roomId 조회할 채팅방 ID
+     * @param userId 조회 요청한 사용자 ID
+     * @return 채팅방 상세 정보
+     * @throws DuckwhoException 채팅방을 찾을 수 없거나, 접근 권한이 없거나, 사용자가 나간 채팅방인 경우
+     */
     public ChatRoomResponseDTO findChatRoom(String roomId, Long userId) {
-        ChatRoom chatRoom = chatRoomRepository.findByRoomId(roomId)
+        // 채팅방과 참여자 정보를 단일 쿼리로 조회
+        ChatRoom chatRoom = chatRoomRepository.findByRoomIdWithParticipants(roomId)
                 .orElseThrow(() -> new DuckwhoException(ErrorCode.CHAT_ROOM_NOT_FOUND));
 
+        // 접근 권한 확인
         if (!chatRoom.isParticipant(userId)) {
             throw new DuckwhoException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
 
-        // 자신이 나간 채팅방은 조회할 수 없음
+        // 채팅방 퇴장 여부 확인
         if (chatRoom.hasUserLeft(userId)) {
             throw new DuckwhoException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
 
-        User buyer = userRepository.findById(chatRoom.getBuyerId())
-                .orElseThrow(() -> new DuckwhoException(ErrorCode.USER_NOT_FOUND));
-        User seller = userRepository.findById(chatRoom.getSellerId())
-                .orElseThrow(() -> new DuckwhoException(ErrorCode.USER_NOT_FOUND));
-
-        return ChatRoomResponseDTO.of(chatRoom, buyer, seller, userId);
+        // JOIN FETCH로 이미 조회된 정보 사용
+        return ChatRoomResponseDTO.of(
+                chatRoom,
+                chatRoom.getBuyer(),
+                chatRoom.getSeller(),
+                userId
+        );
     }
 
+    /**
+     * 특정 채팅방의 읽지 않은 메시지 수를 조회합니다.
+     * MongoDB에 저장된 메타 정보를 통해 효율적으로 조회합니다.
+     *
+     * @param roomId 조회할 채팅방 ID
+     * @param userId 조회 요청한 사용자 ID
+     * @return 읽지 않은 메시지 수
+     * @throws DuckwhoException 채팅방을 찾을 수 없거나 접근 권한이 없는 경우
+     */
     public Integer getChatRoomUnreadCount(String roomId, Long userId) {
+        // 채팅방 메타 정보 조회
         ChatroomMetaInfo metaInfo = chatroomMetaRepository.findById(roomId)
                 .orElseThrow(() -> new DuckwhoException(ErrorCode.CHAT_ROOM_NOT_FOUND));
 
+        // 참여자 정보 확인
         ParticipantInfo participantInfo = metaInfo.getParticipants().getInfo().get(userId.toString());
         if (participantInfo == null) {
             throw new DuckwhoException(ErrorCode.UNAUTHORIZED_ACCESS);
@@ -118,10 +194,20 @@ public class ChatRoomService {
         return participantInfo.getMessageStock();
     }
 
+
+    /**
+     * 사용자의 모든 채팅방에서 읽지 않은 전체 메시지 수를 조회합니다.
+     * MongoDB의 메타 정보를 활용하여 효율적으로 합산합니다.
+     *
+     * @param userId 조회할 사용자 ID
+     * @return 전체 읽지 않은 메시지 수
+     */
     public Integer getTotalUnreadCount(Long userId) {
+        // 사용자가 참여한 모든 채팅방의 메타 정보 조회
         List<ChatroomMetaInfo> userChatrooms = chatroomMetaRepository
                 .findByParticipantIdOrderByUpdateAtDesc(userId.toString());
 
+        // 읽지 않은 메시지 수 합산
         return userChatrooms.stream()
                 .map(chatroom -> {
                     ParticipantInfo participantInfo = chatroom.getParticipants().getInfo().get(userId.toString());

--- a/src/main/java/com/ani/taku_backend/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/service/ChatRoomService.java
@@ -52,26 +52,26 @@ public class ChatRoomService {
         User seller = userRepository.findById(requestDto.sellerId())
                 .orElseThrow(() -> new DuckwhoException(ErrorCode.USER_NOT_FOUND));
 
-        return ChatRoomResponseDTO.of(savedRoom, buyer, seller);
+        return ChatRoomResponseDTO.of(savedRoom, buyer, seller, requestDto.buyerId());
     }
 
     public List<ChatRoomResponseDTO> findChatRoomList(Long userId) {
-        List<ChatRoom> buyerRooms = chatRoomRepository
-                .findByStatusAndBuyerIdOrderByCreatedAtDesc(ChatRoomStatus.ACTIVE, userId);
-        List<ChatRoom> sellerRooms = chatRoomRepository
-                .findByStatusAndSellerIdOrderByCreatedAtDesc(ChatRoomStatus.ACTIVE, userId);
+        // 구매자 또는 판매자로 참여한 모든 채팅방을 가져옴
+        List<ChatRoom> buyerRooms = chatRoomRepository.findByBuyerIdOrderByCreatedAtDesc(userId);
+        List<ChatRoom> sellerRooms = chatRoomRepository.findBySellerIdOrderByCreatedAtDesc(userId);
 
         List<ChatRoom> allRooms = new ArrayList<>();
         allRooms.addAll(buyerRooms);
         allRooms.addAll(sellerRooms);
 
         return allRooms.stream()
+                .filter(chatRoom -> !chatRoom.hasUserLeft(userId)) // 자신이 나간 채팅방은 제외
                 .map(chatRoom -> {
                     User buyer = userRepository.findById(chatRoom.getBuyerId())
                             .orElseThrow(() -> new DuckwhoException(ErrorCode.USER_NOT_FOUND));
                     User seller = userRepository.findById(chatRoom.getSellerId())
                             .orElseThrow(() -> new DuckwhoException(ErrorCode.USER_NOT_FOUND));
-                    return ChatRoomResponseDTO.of(chatRoom, buyer, seller);
+                    return ChatRoomResponseDTO.of(chatRoom, buyer, seller, userId);
                 })
                 .collect(Collectors.toList());
     }
@@ -89,7 +89,12 @@ public class ChatRoomService {
         ChatRoom chatRoom = chatRoomRepository.findByRoomId(roomId)
                 .orElseThrow(() -> new DuckwhoException(ErrorCode.CHAT_ROOM_NOT_FOUND));
 
-        if (!chatRoom.getBuyerId().equals(userId) && !chatRoom.getSellerId().equals(userId)) {
+        if (!chatRoom.isParticipant(userId)) {
+            throw new DuckwhoException(ErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        // 자신이 나간 채팅방은 조회할 수 없음
+        if (chatRoom.hasUserLeft(userId)) {
             throw new DuckwhoException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
 
@@ -98,7 +103,7 @@ public class ChatRoomService {
         User seller = userRepository.findById(chatRoom.getSellerId())
                 .orElseThrow(() -> new DuckwhoException(ErrorCode.USER_NOT_FOUND));
 
-        return ChatRoomResponseDTO.of(chatRoom, buyer, seller);
+        return ChatRoomResponseDTO.of(chatRoom, buyer, seller, userId);
     }
 
     public Integer getChatRoomUnreadCount(String roomId, Long userId) {

--- a/src/main/java/com/ani/taku_backend/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/service/ChatRoomService.java
@@ -10,6 +10,8 @@ import com.ani.taku_backend.chatroom.repository.ChatRoomRepository;
 import com.ani.taku_backend.chatroom.repository.ChatroomMetaRepository;
 import com.ani.taku_backend.common.exception.DuckwhoException;
 import com.ani.taku_backend.common.exception.ErrorCode;
+import com.ani.taku_backend.user.model.entity.User;
+import com.ani.taku_backend.user.repository.UserRepository;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.List;
@@ -24,6 +26,7 @@ public class ChatRoomService {
 
     private final ChatRoomRepository chatRoomRepository;
     private final ChatroomMetaRepository chatroomMetaRepository;
+    private final UserRepository userRepository;
 
     @Transactional
     public ChatRoomResponseDTO createChatRoom(ChatRoomRequestDTO requestDto) {
@@ -44,7 +47,12 @@ public class ChatRoomService {
         metaInfo.initializeParticipants(requestDto.buyerId(), requestDto.sellerId());
         chatroomMetaRepository.save(metaInfo);
 
-        return ChatRoomResponseDTO.of(savedRoom);
+        User buyer = userRepository.findById(requestDto.buyerId())
+                .orElseThrow(() -> new DuckwhoException(ErrorCode.USER_NOT_FOUND));
+        User seller = userRepository.findById(requestDto.sellerId())
+                .orElseThrow(() -> new DuckwhoException(ErrorCode.USER_NOT_FOUND));
+
+        return ChatRoomResponseDTO.of(savedRoom, buyer, seller);
     }
 
     public List<ChatRoomResponseDTO> findChatRoomList(Long userId) {
@@ -58,7 +66,13 @@ public class ChatRoomService {
         allRooms.addAll(sellerRooms);
 
         return allRooms.stream()
-                .map(ChatRoomResponseDTO::of)
+                .map(chatRoom -> {
+                    User buyer = userRepository.findById(chatRoom.getBuyerId())
+                            .orElseThrow(() -> new DuckwhoException(ErrorCode.USER_NOT_FOUND));
+                    User seller = userRepository.findById(chatRoom.getSellerId())
+                            .orElseThrow(() -> new DuckwhoException(ErrorCode.USER_NOT_FOUND));
+                    return ChatRoomResponseDTO.of(chatRoom, buyer, seller);
+                })
                 .collect(Collectors.toList());
     }
 
@@ -79,7 +93,12 @@ public class ChatRoomService {
             throw new DuckwhoException(ErrorCode.UNAUTHORIZED_ACCESS);
         }
 
-        return ChatRoomResponseDTO.of(chatRoom);
+        User buyer = userRepository.findById(chatRoom.getBuyerId())
+                .orElseThrow(() -> new DuckwhoException(ErrorCode.USER_NOT_FOUND));
+        User seller = userRepository.findById(chatRoom.getSellerId())
+                .orElseThrow(() -> new DuckwhoException(ErrorCode.USER_NOT_FOUND));
+
+        return ChatRoomResponseDTO.of(chatRoom, buyer, seller);
     }
 
     public Integer getChatRoomUnreadCount(String roomId, Long userId) {


### PR DESCRIPTION
# [Chat] 채팅방 응답에 사용자 정보 추가 및 DTO 구조 개선

## Description
### 1. 이 일이 왜 시작되었는가?
- 채팅방 목록과 상세 조회 시 사용자의 프로필 사진과 닉네임 정보가 필요
- 채팅방에서 한 사용자가 나갔을 때 이를 구분하고 적절한 메시지를 표시해야 함
- 채팅방 나가기 후 메시지 전송 권한 관리 필요
-  ChatRoomController에 Swagger API 문서화 추가 필요


### 2. 배경 설명
- 기존에는 채팅방 상태가 단순히 ACTIVE/INACTIVE로만 구분
- 누가 채팅방을 나갔는지 구분할 수 없었음

## Changes

### 1. 채팅방 상태 관리 개선
- `ChatRoomLeftBy` enum 추가
  - NONE, BUYER, SELLER 상태 구분
  - 각 상태별 메시지 정의
- `ChatRoom` 엔티티에 `leftBy` 필드 추가
- 채팅방 나가기 관련 메서드 개선
  - `hasUserLeft`: 사용자의 퇴장 여부 확인
  - `canSendMessage`: 메시지 전송 권한 확인
  - `getExitMessage`: 퇴장 메시지 반환

### 2. ChatRoomResponseDTO 구조 개선
- 도메인 개념에 맞춰 계층적으로 재구성
  ```java
  public record ChatRoomResponseDTO(
      ChatRoomInfoDTO info,          // 채팅방 기본 정보
      ParticipantsDTO participants,  // 참여자 정보
      ChatRoomStatusDTO status       // 채팅방 상태 정보
  )
  ```
- 각 하위 DTO의 역할
  - `ChatRoomInfoDTO`: id, roomId, articleId, createdAt
  - `ParticipantsDTO`: buyer와 seller의 상세 정보(닉네임, 프로필 이미지)
  - `ChatRoomStatusDTO`: 메시지 전송 가능 여부, 퇴장 메시지

### 3. 채팅방 조회 로직 수정
- 채팅방 목록 조회 시 나간 사용자 제외
- 채팅방 상세 조회 시 접근 권한 체크 강화
- 사용자 정보(닉네임, 프로필 이미지) 포함하여 응답

