### PR TITLE
[BugFix] 수정한 커뮤니티 전체조회 api가 여러이미지를 반환하면 이미지의 개수만큼 게시글을 생성하는 문제 해결

### DIFF
--- a/src/main/java/com/ani/taku_backend/post/repository/impl/PostRepositoryCustomImpl.java
+++ b/src/main/java/com/ani/taku_backend/post/repository/impl/PostRepositoryCustomImpl.java
@@ -7,6 +7,7 @@ import com.ani.taku_backend.post.model.dto.QFindPostQueryDTO;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,7 +47,7 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
                         post.category.id,
                         post.title,
                         post.content,
-                        communityImage.image.imageUrl,
+                        image.imageUrl,
                         post.updatedAt,
                         post.views,
                         post.user.nickname,
@@ -57,13 +58,12 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
                 .leftJoin(communityImage.image, image)
                 .where(predicate)
                 .orderBy(orderSpecifier)
+                .groupBy(post.id)
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
 
         Long countActivePostsByCategory = getCountActivePostsByCategory(categoryId);
-
-        log.info("총 게시글 개수: {}", countActivePostsByCategory);
 
         return new PageImpl<>(results, pageable, countActivePostsByCategory);
     }


### PR DESCRIPTION
## Description
[커뮤니티 게시글 전체조회에서 이미지의 개수마다 게시글을 생성하는 문제 해결]
- 여러 게시글이 생성되어도 게시글 id로 묶으면 mysql을 사용하기 때문에 가장 먼저 생성된 게시글이 반환되어, 제일 앞 이미지가 반환되도록 보장할 수 있음

## Changes
- PostRepositoryCustomImpl에서 group by를 통해 한개 여러 게시글을 한개만 반환하도록 변경

