### PR TITLE
[Feature] 게시글 상세 조회 기능 개선 및 좋아요 확인 기능 구현 및 댓글 시스템 버그 수정

### DIFF
--- a/src/main/java/com/ani/taku_backend/comments/model/dto/CommentsResponseDTO.java
+++ b/src/main/java/com/ani/taku_backend/comments/model/dto/CommentsResponseDTO.java
@@ -28,7 +28,7 @@ public record CommentsResponseDTO(
         @Schema(description = "대댓글 목록")
         List<CommentsResponseDTO> replies
 ) {
-    public static CommentsResponseDTO of(Comments comment, Long currentUserId) {
+    public static CommentsResponseDTO of(Comments comment, Long currentUserId, List<CommentsResponseDTO> replies) {
         return new CommentsResponseDTO(
                 comment.getId(),
                 comment.getContent(),
@@ -40,7 +40,11 @@ public record CommentsResponseDTO(
                         .ageRange(comment.getUser().getAgeRange())
                         .build(),
                 currentUserId != null && currentUserId.equals(comment.getUser().getUserId()),
-                List.of()
+                replies
         );
+    }
+
+    public static CommentsResponseDTO of(Comments comment, Long currentUserId) {
+        return of(comment, currentUserId, List.of());
     }
 }

--- a/src/main/java/com/ani/taku_backend/comments/model/entity/Comments.java
+++ b/src/main/java/com/ani/taku_backend/comments/model/entity/Comments.java
@@ -8,6 +8,8 @@ import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Builder
 @Entity
@@ -33,6 +35,10 @@ public class Comments extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_comment_id")
     private Comments parentComment;
+
+    @OneToMany(mappedBy = "parentComment")
+    @Builder.Default
+    private List<Comments> replies = new ArrayList<>();
 
     @Column(length = 255, nullable = false)
     private String content;

--- a/src/main/java/com/ani/taku_backend/comments/repository/CommentsRepository.java
+++ b/src/main/java/com/ani/taku_backend/comments/repository/CommentsRepository.java
@@ -8,26 +8,18 @@ import java.util.List;
 
 public interface CommentsRepository extends JpaRepository<Comments, Long> {
     /**
-     * 게시글의 모든 댓글을 계층 구조로 조회합니다.
+     * 게시글의 모든 댓글을 한 번에 조회합니다.
      * 부모 댓글과 자식 댓글, 그리고 각 댓글의 작성자 정보를 함께 조회합니다.
      */
     @Query("""
             SELECT DISTINCT c FROM Comments c
+            LEFT JOIN FETCH c.parentComment
             JOIN FETCH c.user
             WHERE c.post.id = :postId
             AND c.deletedAt IS NULL
-            AND c.parentComment IS NULL
-            ORDER BY c.createdAt DESC
+            ORDER BY 
+                CASE WHEN c.parentComment IS NULL THEN c.createdAt ELSE c.parentComment.createdAt END DESC,
+                CASE WHEN c.parentComment IS NULL THEN 0 ELSE c.createdAt END ASC
             """)
-    List<Comments> findParentComments(@Param("postId") Long postId);
-
-    @Query("""
-            SELECT DISTINCT c FROM Comments c
-            JOIN FETCH c.user
-            WHERE c.post.id = :postId
-            AND c.deletedAt IS NULL
-            AND c.parentComment.id = :parentCommentId
-            ORDER BY c.createdAt ASC
-            """)
-    List<Comments> findRepliesByParentCommentId(@Param("postId") Long postId, @Param("parentCommentId") Long parentCommentId);
+    List<Comments> findAllCommentsWithParent(@Param("postId") Long postId);
 }

--- a/src/main/java/com/ani/taku_backend/comments/repository/CommentsRepository.java
+++ b/src/main/java/com/ani/taku_backend/comments/repository/CommentsRepository.java
@@ -13,12 +13,21 @@ public interface CommentsRepository extends JpaRepository<Comments, Long> {
      */
     @Query("""
             SELECT DISTINCT c FROM Comments c
-            LEFT JOIN c.parentComment p
             JOIN FETCH c.user
             WHERE c.post.id = :postId
             AND c.deletedAt IS NULL
-            ORDER BY CASE WHEN c.parentComment IS NULL THEN c.createdAt ELSE p.createdAt END DESC,
-                     CASE WHEN c.parentComment IS NULL THEN 0 ELSE c.createdAt END ASC
+            AND c.parentComment IS NULL
+            ORDER BY c.createdAt DESC
             """)
     List<Comments> findParentComments(@Param("postId") Long postId);
+
+    @Query("""
+            SELECT DISTINCT c FROM Comments c
+            JOIN FETCH c.user
+            WHERE c.post.id = :postId
+            AND c.deletedAt IS NULL
+            AND c.parentComment.id = :parentCommentId
+            ORDER BY c.createdAt ASC
+            """)
+    List<Comments> findRepliesByParentCommentId(@Param("postId") Long postId, @Param("parentCommentId") Long parentCommentId);
 }

--- a/src/main/java/com/ani/taku_backend/comments/service/CommentsServiceImpl.java
+++ b/src/main/java/com/ani/taku_backend/comments/service/CommentsServiceImpl.java
@@ -152,21 +152,22 @@ public class CommentsServiceImpl implements CommentsService {
     @Override
     @Transactional(readOnly = true)
     public List<CommentsResponseDTO> getPostComments(Long postId, Long currentUserId) {
-        // 부모 댓글만 조회
-        List<Comments> parentComments = commentsRepository.findParentComments(postId);
+        // 모든 댓글을 한 번에 조회
+        List<Comments> allComments = commentsRepository.findAllCommentsWithParent(postId);
         
-        return parentComments.stream()
-                .map(comment -> {
-                    // 각 부모 댓글의 대댓글 조회
-                    List<Comments> replies = commentsRepository.findRepliesByParentCommentId(postId, comment.getId());
-                    
-                    // 대댓글들을 DTO로 변환
-                    List<CommentsResponseDTO> replyDtos = replies.stream()
+        // 부모 댓글만 필터링
+        return allComments.stream()
+                .filter(comment -> comment.getParentComment() == null)  // 부모 댓글만 선택
+                .map(parentComment -> {
+                    // 현재 부모 댓글의 자식 댓글들 찾기
+                    List<CommentsResponseDTO> replyDtos = allComments.stream()
+                            .filter(comment -> comment.getParentComment() != null 
+                                    && comment.getParentComment().getId() == parentComment.getId())
                             .map(reply -> CommentsResponseDTO.of(reply, currentUserId))
                             .toList();
                     
                     // 부모 댓글 DTO 생성 (대댓글 목록 포함)
-                    return CommentsResponseDTO.of(comment, currentUserId, replyDtos);
+                    return CommentsResponseDTO.of(parentComment, currentUserId, replyDtos);
                 })
                 .toList();
     }

--- a/src/main/java/com/ani/taku_backend/comments/service/CommentsServiceImpl.java
+++ b/src/main/java/com/ani/taku_backend/comments/service/CommentsServiceImpl.java
@@ -152,33 +152,21 @@ public class CommentsServiceImpl implements CommentsService {
     @Override
     @Transactional(readOnly = true)
     public List<CommentsResponseDTO> getPostComments(Long postId, Long currentUserId) {
-        // 최상위 댓글과 대댓글을 함께 조회 (단일 쿼리로 모든 데이터를 가져옴)
+        // 부모 댓글만 조회
         List<Comments> parentComments = commentsRepository.findParentComments(postId);
-
-        // 각 댓글에 대한 ResponseDTO 생성
+        
         return parentComments.stream()
                 .map(comment -> {
-                    CommentsResponseDTO parentDto = CommentsResponseDTO.of(comment, currentUserId);
-
-                    // JOIN으로 이미 조회된 자식 댓글들을 필터링하고 정렬
-                    List<CommentsResponseDTO> replyDtos = comment.getParentComment() == null ? // 부모 댓글인 경우에만
-                            parentComments.stream()
-                                    .filter(reply -> reply.getParentComment() != null
-                                            && reply.getParentComment().getId() == comment.getId()
-                                            && reply.getDeletedAt() == null)
-                                    .sorted((r1, r2) -> r1.getCreatedAt().compareTo(r2.getCreatedAt()))
-                                    .map(reply -> CommentsResponseDTO.of(reply, currentUserId))
-                                    .toList()
-                            : List.of(); // 자식 댓글인 경우 빈 리스트 반환
-
-                    return new CommentsResponseDTO(
-                            parentDto.id(),
-                            parentDto.content(),
-                            parentDto.createdAt(),
-                            parentDto.user(),
-                            parentDto.isOwner(),
-                            replyDtos
-                    );
+                    // 각 부모 댓글의 대댓글 조회
+                    List<Comments> replies = commentsRepository.findRepliesByParentCommentId(postId, comment.getId());
+                    
+                    // 대댓글들을 DTO로 변환
+                    List<CommentsResponseDTO> replyDtos = replies.stream()
+                            .map(reply -> CommentsResponseDTO.of(reply, currentUserId))
+                            .toList();
+                    
+                    // 부모 댓글 DTO 생성 (대댓글 목록 포함)
+                    return CommentsResponseDTO.of(comment, currentUserId, replyDtos);
                 })
                 .toList();
     }

--- a/src/main/java/com/ani/taku_backend/post/controller/PostController.java
+++ b/src/main/java/com/ani/taku_backend/post/controller/PostController.java
@@ -21,6 +21,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 @RestController
 @Slf4j
@@ -88,11 +89,14 @@ public class PostController {
     public CommonResponse<PostDetailResponseDTO> findPostDetail(
             @Parameter(description = "게시글 ID") @PathVariable Long postId,
             @Parameter(description = "조회수 증가 여부") @ViewCountChecker Boolean canAddView,
-            @Parameter(description = "로그인한 사용자 정보 (없을 경우 null)", hidden = true) PrincipalUser principalUser) {
+            @Parameter(description = "로그인한 사용자 정보 (없을 경우 null)", hidden = true) 
+            @AuthenticationPrincipal PrincipalUser principalUser) {
+            
         Long currentUserId = null;
         if (principalUser != null && principalUser.getUser() != null) {
             currentUserId = principalUser.getUser().getUserId();
         }
+        
         PostDetailResponseDTO detail = postService.getPostDetail(postId, canAddView, currentUserId);
         return CommonResponse.ok(detail);
     }

--- a/src/main/java/com/ani/taku_backend/post/model/dto/PostDetailResponseDTO.java
+++ b/src/main/java/com/ani/taku_backend/post/model/dto/PostDetailResponseDTO.java
@@ -14,8 +14,16 @@ public class PostDetailResponseDTO {
 
     @Schema(description = "게시글 ID")
     private final Long postId;
+    
+    @Schema(description = "작성자 닉네임")
+    private final String authorNickname;
+    
+    @Schema(description = "작성자 프로필 이미지 URL")
+    private final String authorProfileUrl;
+    
     @Schema(description = "게시글 제목")
     private final String title;
+    
     @Schema(description = "게시글 본문")
     private final String content;
 
@@ -43,6 +51,8 @@ public class PostDetailResponseDTO {
 
     public PostDetailResponseDTO(Post post, boolean owner, List<CommentsResponseDTO> comments, long likeCount) {
         this.postId = post.getId();
+        this.authorNickname = post.getUser().getNickname();
+        this.authorProfileUrl = post.getUser().getProfileImg();
         this.title = post.getTitle();
         this.content = post.getContent();
         this.updateAt = post.getUpdatedAt();

--- a/src/main/java/com/ani/taku_backend/post/model/dto/PostDetailResponseDTO.java
+++ b/src/main/java/com/ani/taku_backend/post/model/dto/PostDetailResponseDTO.java
@@ -49,7 +49,10 @@ public class PostDetailResponseDTO {
     @Schema(description = "좋아요 수")
     private final long likeCount;
 
-    public PostDetailResponseDTO(Post post, boolean owner, List<CommentsResponseDTO> comments, long likeCount) {
+    @Schema(description = "현재 사용자가 좋아요를 눌렀는지 여부")
+    private final boolean isLiked;
+
+    public PostDetailResponseDTO(Post post, boolean owner, List<CommentsResponseDTO> comments, long likeCount, boolean isLiked) {
         this.postId = post.getId();
         this.authorNickname = post.getUser().getNickname();
         this.authorProfileUrl = post.getUser().getProfileImg();
@@ -60,6 +63,7 @@ public class PostDetailResponseDTO {
         this.categoryId = post.getCategory().getId();
         this.owner = owner;
         this.likeCount = likeCount;
+        this.isLiked = isLiked;
 
         this.imageUrls = post.getCommunityImages().stream()
                 .map(communityImage -> communityImage.getImage().getImageUrl())

--- a/src/main/java/com/ani/taku_backend/post/model/entity/Post.java
+++ b/src/main/java/com/ani/taku_backend/post/model/entity/Post.java
@@ -96,7 +96,7 @@ public class Post extends BaseTimeEntity {
 
     // 조회수 증가
     public void addViews() {
-        this.views++;
+        this.views += 1;
     }
 
 

--- a/src/main/java/com/ani/taku_backend/post/model/entity/PostInteractionCounter.java
+++ b/src/main/java/com/ani/taku_backend/post/model/entity/PostInteractionCounter.java
@@ -7,6 +7,8 @@ import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
 import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
 
 @Document(collection = "posts_interaction_counter")
 @Getter
@@ -25,6 +27,10 @@ public class PostInteractionCounter {
     @Field(name = "category_id")
     private Long categoryId; // 카테고리 ID 추가
 
+    @Field(name = "liked_user_ids")
+    @Builder.Default
+    private Set<Long> likedUserIds = new HashSet<>(); // 좋아요를 누른 사용자 ID 목록
+
     @Field(name = "deleted_at", write = Field.Write.ALWAYS)
     private LocalDateTime deletedAt; // 삭제 여부 (삭제되지 않았으면 null)
 
@@ -34,6 +40,7 @@ public class PostInteractionCounter {
                 .postLikes(0L)
                 .categoryId(post.getCategory().getId())
                 .deletedAt(post.getDeletedAt())
+                .likedUserIds(new HashSet<>())
                 .build();
     }
 

--- a/src/main/java/com/ani/taku_backend/post/repository/PostRepository.java
+++ b/src/main/java/com/ani/taku_backend/post/repository/PostRepository.java
@@ -5,9 +5,19 @@ import com.ani.taku_backend.post.model.entity.Post;
 import com.ani.taku_backend.post.repository.impl.PostRepositoryCustom;
 import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
+
 public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
+
+    @Modifying(clearAutomatically = true)
+    @Query(value = "UPDATE posts SET views = views + 1 WHERE id = :postId", nativeQuery = true)
+    void incrementViewCount(@Param("postId") Long postId);
+
+    @Query("SELECT p FROM Post p LEFT JOIN FETCH p.communityImages ci LEFT JOIN FETCH ci.image WHERE p.id = :postId AND p.deletedAt IS NULL")
+    Optional<Post> findByIdWithImages(@Param("postId") Long postId);
 
 }

--- a/src/main/java/com/ani/taku_backend/post/repository/PostRepository.java
+++ b/src/main/java/com/ani/taku_backend/post/repository/PostRepository.java
@@ -17,7 +17,11 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
     @Query(value = "UPDATE posts SET views = views + 1 WHERE id = :postId", nativeQuery = true)
     void incrementViewCount(@Param("postId") Long postId);
 
-    @Query("SELECT p FROM Post p LEFT JOIN FETCH p.communityImages ci LEFT JOIN FETCH ci.image WHERE p.id = :postId AND p.deletedAt IS NULL")
+    @Query("SELECT p FROM Post p " +
+           "LEFT JOIN FETCH p.user " +
+           "LEFT JOIN FETCH p.communityImages ci " +
+           "LEFT JOIN FETCH ci.image " +
+           "WHERE p.id = :postId AND p.deletedAt IS NULL")
     Optional<Post> findByIdWithImages(@Param("postId") Long postId);
 
 }

--- a/src/main/java/com/ani/taku_backend/post/repository/impl/PostInteractionCounterRepositoryCustom.java
+++ b/src/main/java/com/ani/taku_backend/post/repository/impl/PostInteractionCounterRepositoryCustom.java
@@ -17,4 +17,6 @@ public interface PostInteractionCounterRepositoryCustom {
     void updateDeletedAt(Post post);
 
     Map<Long, Long> findLikesByPostIds(List<Long> postIds);
+    
+    boolean isPostLikedByUser(Long postId, Long userId);
 }

--- a/src/main/java/com/ani/taku_backend/post/repository/impl/PostInteractionCounterRepositoryCustomImpl.java
+++ b/src/main/java/com/ani/taku_backend/post/repository/impl/PostInteractionCounterRepositoryCustomImpl.java
@@ -104,4 +104,18 @@ public class PostInteractionCounterRepositoryCustomImpl implements PostInteracti
                 .collect(Collectors.toMap(PostInteractionCounter::getPostId, PostInteractionCounter::getPostLikes));
     }
 
+    /**
+     * 특정 사용자가 게시글에 좋아요를 눌렀는지 확인
+     * @param postId 게시글 ID
+     * @param userId 사용자 ID
+     * @return 좋아요 여부
+     */
+    @Override
+    public boolean isPostLikedByUser(Long postId, Long userId) {
+        Query query = new Query(Criteria.where(ID.getField()).is(postId)
+                .and("liked_user_ids").in(userId));
+        return mongoTemplate.exists(query, PostInteractionCounter.class);
+    }
+
+
 }

--- a/src/main/java/com/ani/taku_backend/post/service/PostServiceImpl.java
+++ b/src/main/java/com/ani/taku_backend/post/service/PostServiceImpl.java
@@ -153,33 +153,22 @@ public class PostServiceImpl implements PostService {
      */
     @Transactional
     public PostDetailResponseDTO getPostDetail(Long postId, boolean canAddView, Long currentUserId) {
-        Post post = postRepository.findByIdWithImages(postId)
+        Post findPost = postRepository.findByIdWithImages(postId)
                 .orElseThrow(() -> new DuckwhoException(NOT_FOUND_POST));
 
-        if (post.getDeletedAt() != null) {
-            throw new DuckwhoException(NOT_FOUND_POST);
-        }
+        checkDeleteProduct(findPost);
 
-        // 조회수 증가 로직을 별도의 트랜잭션으로 처리
         if (canAddView) {
             postRepository.incrementViewCount(postId);
         }
 
-        // 비로그인 사용자는 항상 false
-        boolean isOwner = false;
-        
-        // 로그인한 사용자인 경우에만 소유자 체크
-        if (currentUserId != null && post.getUser() != null) {
-            isOwner = post.getUser().getUserId().equals(currentUserId);
-        }
+        boolean isOwner = currentUserId != null && currentUserId.equals(findPost.getUser().getUserId());
+        long likeCount = getPostLikeCount(postId);
+        boolean isLiked = currentUserId != null && postInteractionCounterRepository.isPostLikedByUser(postId, currentUserId);
 
-        // 댓글 목록 조회
         List<CommentsResponseDTO> comments = commentsService.getPostComments(postId, currentUserId);
 
-        // MongoDB에서 좋아요 수 조회
-        long likeCount = getPostLikeCount(postId);
-
-        return new PostDetailResponseDTO(post, isOwner, comments, likeCount);
+        return new PostDetailResponseDTO(findPost, isOwner, comments, likeCount, isLiked);
     }
 
     /**

--- a/src/main/java/com/ani/taku_backend/post/service/PostServiceImpl.java
+++ b/src/main/java/com/ani/taku_backend/post/service/PostServiceImpl.java
@@ -153,15 +153,16 @@ public class PostServiceImpl implements PostService {
      */
     @Transactional
     public PostDetailResponseDTO getPostDetail(Long postId, boolean canAddView, Long currentUserId) {
-        Post post = postRepository.findById(postId)
+        Post post = postRepository.findByIdWithImages(postId)
                 .orElseThrow(() -> new DuckwhoException(NOT_FOUND_POST));
 
         if (post.getDeletedAt() != null) {
             throw new DuckwhoException(NOT_FOUND_POST);
         }
 
+        // 조회수 증가 로직을 별도의 트랜잭션으로 처리
         if (canAddView) {
-            post.addViews();
+            postRepository.incrementViewCount(postId);
         }
 
         // 비로그인 사용자는 항상 false


### PR DESCRIPTION
# [Feature] 게시글 상세 조회 기능 개선 및 좋아요 시스템 구현

## Description
프론트분 요청에 따라
1. 대댓글 중복 표시 문제 해결
2. 상세 조회시 게시글 작성자 정보에 닉네임과 프로필 이미지를 추가
3. 좋아요한 사람들은 좋아요 했다고 확인할 수 있는 기능
에 대한 수정 및 기능 추가가 필요했습니다. 
개발하던 중에 
게시글 상세 조회 시 사용자 인증 정보가 제대로 전달되지 않아 좋아요 상태가 항상 false로 표시되는 문제가 발생했습니다. 이를 해결하기 위해 Spring Security의 인증 시스템을 개선하고, 게시글 상세 정보에 작성자 정보와 좋아요 상태를 추가했습니다.

## Changes
 게시글 상세 조회 인증 시스템 개선
   - PostController.findPostDetail에 `@AuthenticationPrincipal` 어노테이션 추가
   - Spring Security가 SecurityContext에서 인증된 사용자 정보를 정상적으로 주입하도록 보장

게시글 좋아요 여부 확인 시스템 구현
   - PostInteractionCounter 엔티티에 likedUserIds 필드 추가
   - PostDetailResponseDTO에 isLiked 필드 추가
   - PostInteractionCounterRepositoryCustom에 isPostLikedByUser 메서드 추가
   - 게시글 상세 조회 시 현재 사용자의 좋아요 여부 반환 기능 구현

게시글 작성자 정보 표시 개선
   - PostDetailResponseDTO에 작성자 닉네임과 프로필 이미지 URL 필드 추가
   - LazyInitializationException 해결을 위한 PostRepository.findByIdWithImages() 쿼리 개선
     - Post 조회 시 User 정보를 함께 조회 (LEFT JOIN FETCH)
     - 연관된 CommunityImages와 Image 정보 함께 조회 (N+1 문제 방지)

댓글 시스템 버그 수정
   - 대댓글 중복 표시 문제 해결
   - 댓글/대댓글 작성 시 게시글 수정일자 업데이트 로직 수정

### 트러블 슈팅
인증 정보 전달 문제  
   - 문제: PublicEndpointFilter에서 사용자 정보(userId=58)가 존재함에도 컨트롤러에서 수신되지 않음
   - 원인: Spring Security의 인증 컨텍스트에서 사용자 정보를 메서드 파라미터로 주입하는 어노테이션이 누락
   - 해결: `@AuthenticationPrincipal` 어노테이션을 추가하여 인증된 사용자 정보를 올바르게 주입


## Ref
- [Spring Security @AuthenticationPrincipal 문서](https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/core/annotation/AuthenticationPrincipal.html)
- [MongoDB 복합 인덱스 설계 가이드](https://www.mongodb.com/docs/manual/core/index-compound/)

## Test
1.몽고 디비에 직접 조회하여 좋아요 누른 사람의 리스트를 확인합니다. postid는 20479 기준으로 테스트 했습니다.
 ![image](https://github.com/user-attachments/assets/0c55c15e-47e5-45f4-867f-d995efe63ca3)
2. 이 중에서 id 가 58 유저로 테스트 했습니다. 토큰은 노션에  hayani0000@gmail.com에 해당하는 토큰으로 인증하시면 됩니다.hayani0000@gmail.com 유저id가 58번 즉 , 좋아요를 누른 상태이므로 토큰인증을 했을때 liked라는 값이 true가 나와야합니다. 
3.스웨거 상에서 확인하면 liked가 true라고 떠있는 결과를 확인 가능합니다. 
![image](https://github.com/user-attachments/assets/c095c8aa-045b-4794-bc74-0ca5cd292278)

추가적으로 좋아요 여부를 판단했을 때는 다음의 결과대로 나오게 됩니다. 
- 로그인한 경우:
    - 해당 게시물에 좋아요를 눌렀으면 liked가 true로 반환
    - 해당게시물에 좋아요를 누른적이 없다면 false로 반환
 - 비로그인 경우:
     - 무조건 liked false 로 반환 
    
