### PR TITLE
[ADMIN] 카테고리 상태 변경

### DIFF
--- a/src/main/java/com/ani/taku_backend/admin/category/controller/AdminCategoryController.java
+++ b/src/main/java/com/ani/taku_backend/admin/category/controller/AdminCategoryController.java
@@ -1,22 +1,26 @@
 package com.ani.taku_backend.admin.category.controller;
 
-import com.ani.taku_backend.admin.category.dto.req.AdminCategoryListReqDTO;
-import com.ani.taku_backend.admin.category.dto.req.UpdateCategoryReqDTO;
-import com.ani.taku_backend.admin.category.dto.res.AdminCategoryListResDTO;
+import com.ani.taku_backend.admin.category.domain.dto.req.AdminCategoryListReqDTO;
+import com.ani.taku_backend.admin.category.domain.dto.req.UpdateCategoryReqDTO;
+import com.ani.taku_backend.admin.category.domain.dto.res.AdminCategoryListResDTO;
 import com.ani.taku_backend.admin.category.service.AdminCategoryService;
-import com.ani.taku_backend.common.response.CommonResponse;
 import com.ani.taku_backend.user.model.dto.PrincipalUser;
 import com.ani.taku_backend.user.model.entity.User;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@Controller
 @RequestMapping("/admin/category")
+@Controller
+@Validated
 @RequiredArgsConstructor
 public class AdminCategoryController {
     private final AdminCategoryService adminCategoryService;
@@ -38,12 +42,10 @@ public class AdminCategoryController {
         return "category/list";
     }
 
-    @GetMapping
+    @PutMapping("/status")
     public String updateCategoryStatus(@AuthenticationPrincipal PrincipalUser principalUser,
-        UpdateCategoryReqDTO updateCategoryReqDTO) {
-
+        @Valid @RequestBody UpdateCategoryReqDTO updateCategoryReqDTO) {
         User user = principalUser.getUser();
-
         adminCategoryService.updateCategoryStatus(user, updateCategoryReqDTO);
 
         return "category/list";

--- a/src/main/java/com/ani/taku_backend/admin/category/controller/AdminCategoryController.java
+++ b/src/main/java/com/ani/taku_backend/admin/category/controller/AdminCategoryController.java
@@ -1,8 +1,10 @@
 package com.ani.taku_backend.admin.category.controller;
 
 import com.ani.taku_backend.admin.category.dto.req.AdminCategoryListReqDTO;
+import com.ani.taku_backend.admin.category.dto.req.UpdateCategoryReqDTO;
 import com.ani.taku_backend.admin.category.dto.res.AdminCategoryListResDTO;
 import com.ani.taku_backend.admin.category.service.AdminCategoryService;
+import com.ani.taku_backend.common.response.CommonResponse;
 import com.ani.taku_backend.user.model.dto.PrincipalUser;
 import com.ani.taku_backend.user.model.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +34,17 @@ public class AdminCategoryController {
         int num = 300;
         model.addAttribute("d2", str);
         model.addAttribute("d3", num);
+
+        return "category/list";
+    }
+
+    @GetMapping
+    public String updateCategoryStatus(@AuthenticationPrincipal PrincipalUser principalUser,
+        UpdateCategoryReqDTO updateCategoryReqDTO) {
+
+        User user = principalUser.getUser();
+
+        adminCategoryService.updateCategoryStatus(user, updateCategoryReqDTO);
 
         return "category/list";
     }

--- a/src/main/java/com/ani/taku_backend/admin/category/domain/CategoryLog.java
+++ b/src/main/java/com/ani/taku_backend/admin/category/domain/CategoryLog.java
@@ -1,0 +1,18 @@
+package com.ani.taku_backend.admin.category.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "category_log")
+public class CategoryLog {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+    private String categoryId;
+    private String categoryName;
+    private String
+}

--- a/src/main/java/com/ani/taku_backend/admin/category/domain/CategoryLog.java
+++ b/src/main/java/com/ani/taku_backend/admin/category/domain/CategoryLog.java
@@ -1,18 +1,45 @@
 package com.ani.taku_backend.admin.category.domain;
 
+import com.ani.taku_backend.category.domain.entity.Category;
+import com.ani.taku_backend.common.baseEntity.BaseTimeEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "category_log")
-public class CategoryLog {
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class CategoryLog extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
-    private String categoryId;
-    private String categoryName;
-    private String
+    private Long categoryId;
+    private Long userId;
+    private String userName;
+    private String content;
+
+    @Enumerated
+    private CategoryLogType type;
+
+
+    public static CategoryLog create(Category category, Long userId, String userName, String content, CategoryLogType type) {
+        return CategoryLog.builder()
+                .categoryId(category.getId())
+                .userId(userId)
+                .userName(userName)
+                .content(content)
+                .type(type)
+                .build();
+    }
 }

--- a/src/main/java/com/ani/taku_backend/admin/category/domain/CategoryLogType.java
+++ b/src/main/java/com/ani/taku_backend/admin/category/domain/CategoryLogType.java
@@ -1,0 +1,12 @@
+package com.ani.taku_backend.admin.category.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CategoryLogType {
+    CREATE,
+    UPDATE,
+    DELETE;
+}

--- a/src/main/java/com/ani/taku_backend/admin/category/domain/dto/CategorySearchType.java
+++ b/src/main/java/com/ani/taku_backend/admin/category/domain/dto/CategorySearchType.java
@@ -1,4 +1,4 @@
-package com.ani.taku_backend.admin.category.dto;
+package com.ani.taku_backend.admin.category.domain.dto;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/ani/taku_backend/admin/category/domain/dto/req/AdminCategoryListReqDTO.java
+++ b/src/main/java/com/ani/taku_backend/admin/category/domain/dto/req/AdminCategoryListReqDTO.java
@@ -1,6 +1,6 @@
-package com.ani.taku_backend.admin.category.dto.req;
+package com.ani.taku_backend.admin.category.domain.dto.req;
 
-import com.ani.taku_backend.admin.category.dto.CategorySearchType;
+import com.ani.taku_backend.admin.category.domain.dto.CategorySearchType;
 import com.ani.taku_backend.category.domain.entity.CategoryStatus;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/ani/taku_backend/admin/category/domain/dto/req/UpdateCategoryReqDTO.java
+++ b/src/main/java/com/ani/taku_backend/admin/category/domain/dto/req/UpdateCategoryReqDTO.java
@@ -1,6 +1,7 @@
-package com.ani.taku_backend.admin.category.dto.req;
+package com.ani.taku_backend.admin.category.domain.dto.req;
 
 import com.ani.taku_backend.category.domain.entity.CategoryStatus;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,6 +13,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class UpdateCategoryReqDTO {
-    private CategoryStatus status;
+    @NotNull
     private Long categoryId;
+    @NotNull
+    private CategoryStatus categoryStatus;
 }

--- a/src/main/java/com/ani/taku_backend/admin/category/domain/dto/res/AdminCategoryListResDTO.java
+++ b/src/main/java/com/ani/taku_backend/admin/category/domain/dto/res/AdminCategoryListResDTO.java
@@ -1,4 +1,4 @@
-package com.ani.taku_backend.admin.category.dto.res;
+package com.ani.taku_backend.admin.category.domain.dto.res;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/ani/taku_backend/admin/category/domain/dto/res/AdminCategoryResDTO.java
+++ b/src/main/java/com/ani/taku_backend/admin/category/domain/dto/res/AdminCategoryResDTO.java
@@ -1,4 +1,4 @@
-package com.ani.taku_backend.admin.category.dto.res;
+package com.ani.taku_backend.admin.category.domain.dto.res;
 
 import com.ani.taku_backend.category.domain.dto.AniGenreResDTO;
 import com.ani.taku_backend.category.domain.entity.Category;

--- a/src/main/java/com/ani/taku_backend/admin/category/dto/req/UpdateCategoryReqDTO.java
+++ b/src/main/java/com/ani/taku_backend/admin/category/dto/req/UpdateCategoryReqDTO.java
@@ -1,0 +1,17 @@
+package com.ani.taku_backend.admin.category.dto.req;
+
+import com.ani.taku_backend.category.domain.entity.CategoryStatus;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UpdateCategoryReqDTO {
+    private CategoryStatus status;
+    private Long categoryId;
+}

--- a/src/main/java/com/ani/taku_backend/admin/category/repository/CategoryLogRepository.java
+++ b/src/main/java/com/ani/taku_backend/admin/category/repository/CategoryLogRepository.java
@@ -1,0 +1,8 @@
+package com.ani.taku_backend.admin.category.repository;
+
+import com.ani.taku_backend.admin.category.domain.CategoryLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryLogRepository extends JpaRepository<CategoryLog, Long> {
+
+}

--- a/src/main/java/com/ani/taku_backend/admin/category/repository/CustomAdminCategoryRepository.java
+++ b/src/main/java/com/ani/taku_backend/admin/category/repository/CustomAdminCategoryRepository.java
@@ -1,6 +1,6 @@
 package com.ani.taku_backend.admin.category.repository;
 
-import com.ani.taku_backend.admin.category.dto.req.AdminCategoryListReqDTO;
+import com.ani.taku_backend.admin.category.domain.dto.req.AdminCategoryListReqDTO;
 import com.ani.taku_backend.category.domain.entity.Category;
 import org.springframework.data.domain.Page;
 

--- a/src/main/java/com/ani/taku_backend/admin/category/repository/CustomAdminCategoryRepositoryImpl.java
+++ b/src/main/java/com/ani/taku_backend/admin/category/repository/CustomAdminCategoryRepositoryImpl.java
@@ -1,7 +1,7 @@
 package com.ani.taku_backend.admin.category.repository;
 
-import com.ani.taku_backend.admin.category.dto.CategorySearchType;
-import com.ani.taku_backend.admin.category.dto.req.AdminCategoryListReqDTO;
+import com.ani.taku_backend.admin.category.domain.dto.CategorySearchType;
+import com.ani.taku_backend.admin.category.domain.dto.req.AdminCategoryListReqDTO;
 import com.ani.taku_backend.category.domain.entity.Category;
 import com.ani.taku_backend.category.domain.entity.CategoryOrderType;
 import com.ani.taku_backend.category.domain.entity.CategoryStatus;

--- a/src/main/java/com/ani/taku_backend/admin/category/service/AdminCategoryService.java
+++ b/src/main/java/com/ani/taku_backend/admin/category/service/AdminCategoryService.java
@@ -1,10 +1,9 @@
 package com.ani.taku_backend.admin.category.service;
 
-import com.ani.taku_backend.admin.category.dto.req.AdminCategoryListReqDTO;
-import com.ani.taku_backend.admin.category.dto.req.UpdateCategoryReqDTO;
-import com.ani.taku_backend.admin.category.dto.res.AdminCategoryListResDTO;
+import com.ani.taku_backend.admin.category.domain.dto.req.AdminCategoryListReqDTO;
+import com.ani.taku_backend.admin.category.domain.dto.req.UpdateCategoryReqDTO;
+import com.ani.taku_backend.admin.category.domain.dto.res.AdminCategoryListResDTO;
 import com.ani.taku_backend.user.model.entity.User;
-import org.springframework.data.domain.Pageable;
 
 public interface AdminCategoryService {
     AdminCategoryListResDTO findCategoryList(User user, AdminCategoryListReqDTO categoryListReqDTO);

--- a/src/main/java/com/ani/taku_backend/admin/category/service/AdminCategoryService.java
+++ b/src/main/java/com/ani/taku_backend/admin/category/service/AdminCategoryService.java
@@ -1,10 +1,13 @@
 package com.ani.taku_backend.admin.category.service;
 
 import com.ani.taku_backend.admin.category.dto.req.AdminCategoryListReqDTO;
+import com.ani.taku_backend.admin.category.dto.req.UpdateCategoryReqDTO;
 import com.ani.taku_backend.admin.category.dto.res.AdminCategoryListResDTO;
 import com.ani.taku_backend.user.model.entity.User;
 import org.springframework.data.domain.Pageable;
 
 public interface AdminCategoryService {
     AdminCategoryListResDTO findCategoryList(User user, AdminCategoryListReqDTO categoryListReqDTO);
+
+    void updateCategoryStatus(User user, UpdateCategoryReqDTO updateCategoryReqDTO);
 }

--- a/src/main/java/com/ani/taku_backend/admin/category/service/AdminCategoryServiceImpl.java
+++ b/src/main/java/com/ani/taku_backend/admin/category/service/AdminCategoryServiceImpl.java
@@ -1,10 +1,13 @@
 package com.ani.taku_backend.admin.category.service;
 
 import com.ani.taku_backend.admin.category.dto.req.AdminCategoryListReqDTO;
+import com.ani.taku_backend.admin.category.dto.req.UpdateCategoryReqDTO;
 import com.ani.taku_backend.admin.category.dto.res.AdminCategoryListResDTO;
 import com.ani.taku_backend.admin.category.dto.res.AdminCategoryResDTO;
 import com.ani.taku_backend.admin.category.repository.AdminCategoryRepository;
 import com.ani.taku_backend.category.domain.entity.Category;
+import com.ani.taku_backend.common.exception.DuckwhoException;
+import com.ani.taku_backend.common.exception.ErrorCode;
 import com.ani.taku_backend.common.exception.UserException;
 import com.ani.taku_backend.user.model.entity.User;
 import com.ani.taku_backend.user.repository.UserRepository;
@@ -35,5 +38,15 @@ public class AdminCategoryServiceImpl implements AdminCategoryService {
                     )
                 )
                 .build();
+    }
+
+    @Override
+    public void updateCategoryStatus(User user, UpdateCategoryReqDTO updateCategoryReqDTO) {
+        User findUser = userRepository.findById(user.getUserId())
+                .orElseThrow(UserException.UserNotFoundException::new);
+        Category category = categoryRepository.findById(updateCategoryReqDTO.getCategoryId())
+                .orElseThrow(() -> new DuckwhoException(ErrorCode.NOT_FOUND_CATEGORY));
+
+        category.updateCategoryStatus(updateCategoryReqDTO.getStatus());
     }
 }

--- a/src/main/java/com/ani/taku_backend/admin/category/service/AdminCategoryServiceImpl.java
+++ b/src/main/java/com/ani/taku_backend/admin/category/service/AdminCategoryServiceImpl.java
@@ -1,11 +1,15 @@
 package com.ani.taku_backend.admin.category.service;
 
-import com.ani.taku_backend.admin.category.dto.req.AdminCategoryListReqDTO;
-import com.ani.taku_backend.admin.category.dto.req.UpdateCategoryReqDTO;
-import com.ani.taku_backend.admin.category.dto.res.AdminCategoryListResDTO;
-import com.ani.taku_backend.admin.category.dto.res.AdminCategoryResDTO;
+import com.ani.taku_backend.admin.category.domain.CategoryLog;
+import com.ani.taku_backend.admin.category.domain.CategoryLogType;
+import com.ani.taku_backend.admin.category.domain.dto.req.AdminCategoryListReqDTO;
+import com.ani.taku_backend.admin.category.domain.dto.req.UpdateCategoryReqDTO;
+import com.ani.taku_backend.admin.category.domain.dto.res.AdminCategoryListResDTO;
+import com.ani.taku_backend.admin.category.domain.dto.res.AdminCategoryResDTO;
 import com.ani.taku_backend.admin.category.repository.AdminCategoryRepository;
+import com.ani.taku_backend.admin.category.repository.CategoryLogRepository;
 import com.ani.taku_backend.category.domain.entity.Category;
+import com.ani.taku_backend.category.domain.entity.CategoryStatus;
 import com.ani.taku_backend.common.exception.DuckwhoException;
 import com.ani.taku_backend.common.exception.ErrorCode;
 import com.ani.taku_backend.common.exception.UserException;
@@ -15,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -23,6 +28,7 @@ import java.util.List;
 public class AdminCategoryServiceImpl implements AdminCategoryService {
     private final AdminCategoryRepository categoryRepository;
     private final UserRepository userRepository;
+    private final CategoryLogRepository categoryLogRepository;
 
     @Override
     public AdminCategoryListResDTO findCategoryList(User user, AdminCategoryListReqDTO categoryListReqDTO) {
@@ -41,12 +47,21 @@ public class AdminCategoryServiceImpl implements AdminCategoryService {
     }
 
     @Override
+    @Transactional
     public void updateCategoryStatus(User user, UpdateCategoryReqDTO updateCategoryReqDTO) {
         User findUser = userRepository.findById(user.getUserId())
                 .orElseThrow(UserException.UserNotFoundException::new);
         Category category = categoryRepository.findById(updateCategoryReqDTO.getCategoryId())
                 .orElseThrow(() -> new DuckwhoException(ErrorCode.NOT_FOUND_CATEGORY));
 
-        category.updateCategoryStatus(updateCategoryReqDTO.getStatus());
+        CategoryStatus updateCategoryStatus = updateCategoryReqDTO.getCategoryStatus();
+        category.updateCategoryStatus(updateCategoryStatus);
+
+        String content = category.getName() + "의 상태를" + category.getStatus() + "에서 " + updateCategoryStatus + "로 변경하였습니다.";
+
+        CategoryLog categoryLog = CategoryLog.create(category, user.getUserId(), user.getNickname(), content, CategoryLogType.UPDATE);
+
+        categoryRepository.save(category);
+        categoryLogRepository.save(categoryLog);
     }
 }

--- a/src/main/java/com/ani/taku_backend/category/domain/entity/Category.java
+++ b/src/main/java/com/ani/taku_backend/category/domain/entity/Category.java
@@ -86,6 +86,10 @@ public class Category extends BaseTimeEntity {
     public void setCategoryImage(CategoryImage categoryImage) {
         this.categoryImage = categoryImage;
     }
+
+    public void updateCategoryStatus(CategoryStatus status) {
+        this.status = status;
+    }
 }
 
 


### PR DESCRIPTION
<!--
 리뷰 요청자와 리뷰어 간의 생산적이고 효율적인 리뷰 진행을 위해 아래 나열된 내용을 참고해서 PR 설명을 작성해주세요!
-->
Title
- '[분류] 내용' 의 형식으로 작성해주세요. ex) [Auth] 로그인 화면 추가

## Description
- Duckwho 앱에서 카테고리 생성시 PENDING 상태가 되며, 앱 내에서는 ACTIVE 상태인 카테고리만 보입니다.
- 관리자는 카테고리의 상태를 변경할 수 있어야 하기 때문에 카테고리의 상태를 변경하는 API가 필요합니다.

## Changes
- category_log 테이블 생성 (데이터 관리용이 아닌 로그 용)
- 상태를 변경시 카테고리에 변경 되며, 로그 테이블에도 저장

## Screenshots

## Ref
