### PR TITLE
[BugFix] kakao 로그인 시 발생하는 버그 해결

### DIFF
--- a/src/main/java/com/ani/taku_backend/auth/service/OAuth2UserService.java
+++ b/src/main/java/com/ani/taku_backend/auth/service/OAuth2UserService.java
@@ -60,22 +60,20 @@ public class OAuth2UserService extends DefaultOAuth2UserService {
             throw new DuckwhoException(UNSUPPORTED_PROVIDER);   // 제공하지 않은 OAuth로 인증 시도
         }
 
-        // 이메일 구하기
-        String email;
+        // 이메일로 찾기 -> domesticId로 찾기로 변경, email이 null 이여도 로그인 됨
+        String domesticId;
         switch (providerType) {
             case GOOGLE:
-                email = (String) attributes.get("email");
+                domesticId = attributes.get("sub").toString();
                 break;
             case KAKAO:
-                Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
-                email = (String) kakaoAccount.get("email");
+                domesticId = attributes.get("id").toString();
                 break;
             default:
                 throw new DuckwhoException(UNSUPPORTED_PROVIDER);   // 제공하지 않은 OAuth로 인증 시도
         }
 
-        // User Select
-        Optional<User> findOptUser = userRepository.findByEmail(email);
+        Optional<User> findOptUser = userRepository.findByDomesticId(domesticId);
 
         // HttpServletRequest 가져오기
         ServletRequestAttributes requestAttributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
@@ -118,7 +116,7 @@ public class OAuth2UserService extends DefaultOAuth2UserService {
             log.error("유저 정보 추출 실패", e);
             throw new OAuth2AuthenticationException("유저 정보 추출 실패");
         }
-
+        log.info("OAuth2 attributes: {}", attributes);
         // 유저가 있으면 유저 정보 반환
         DefaultOAuth2User getOAuth2User = null;
         switch (providerType) {
@@ -127,6 +125,7 @@ public class OAuth2UserService extends DefaultOAuth2UserService {
                 break;
             case KAKAO:
                 getOAuth2User = new DefaultOAuth2User(AuthorityUtils.createAuthorityList(findOptUser.get().getRole().name()), attributes, "id");
+
                 break;
         }
         return getOAuth2User;

--- a/src/main/java/com/ani/taku_backend/auth/service/OAuth2UserService.java
+++ b/src/main/java/com/ani/taku_backend/auth/service/OAuth2UserService.java
@@ -116,7 +116,7 @@ public class OAuth2UserService extends DefaultOAuth2UserService {
             log.error("유저 정보 추출 실패", e);
             throw new OAuth2AuthenticationException("유저 정보 추출 실패");
         }
-        log.info("OAuth2 attributes: {}", attributes);
+
         // 유저가 있으면 유저 정보 반환
         DefaultOAuth2User getOAuth2User = null;
         switch (providerType) {

--- a/src/main/java/com/ani/taku_backend/user/repository/UserRepository.java
+++ b/src/main/java/com/ani/taku_backend/user/repository/UserRepository.java
@@ -27,8 +27,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
   @Query("UPDATE User u SET u.status = :status WHERE u.userId = :userId")
   int updateUserStatus(@Param("userId") Long userId, @Param("status") UserStatus status);
 
-  // 이메일로 유저 조회
-  Optional<User> findByEmail(String email);
+  // 도메스틱 아이디로 유저 조회
+  Optional<User> findByDomesticId(String domesticId);
 
   Optional<User> findById(Long userId);
 

--- a/src/test/java/com/ani/taku_backend/init/CommentsInit.java
+++ b/src/test/java/com/ani/taku_backend/init/CommentsInit.java
@@ -41,7 +41,7 @@ public class CommentsInit {
     @Autowired
     EntityManager entityManager;
 
-    @Test
+//    @Test
     void init() throws InterruptedException {
 
         int batchSize = 500;

--- a/src/test/java/com/ani/taku_backend/init/ItemCategoriesInit.java
+++ b/src/test/java/com/ani/taku_backend/init/ItemCategoriesInit.java
@@ -12,7 +12,7 @@ public class ItemCategoriesInit {
     @Autowired
     ItemCategoriesRepository itemCategoriesRepository;
 
-    @Test
+//    @Test
     void init() {
         ItemCategories[] itemCategoryList = {
                 new ItemCategories(null, "디지털기기"),

--- a/src/test/java/com/ani/taku_backend/init/JangterInit.java
+++ b/src/test/java/com/ani/taku_backend/init/JangterInit.java
@@ -41,7 +41,7 @@ public class JangterInit {
     @Autowired
     ItemCategoriesRepository itemCategoriesRepository;
 
-    @Test
+//    @Test
     void init() throws InterruptedException {
         int minPrice = 1000;
         int maxPrice = 100000;

--- a/src/test/java/com/ani/taku_backend/init/JangterInit.java
+++ b/src/test/java/com/ani/taku_backend/init/JangterInit.java
@@ -46,7 +46,7 @@ public class JangterInit {
         int minPrice = 1000;
         int maxPrice = 100000;
         int batchSize = 500;
-        int totalJangters = 10000;
+        int totalJangters = 500;
         int threadCount = 4;
 
         List<User> allUser = userRepository.findAll();

--- a/src/test/java/com/ani/taku_backend/init/PostInit.java
+++ b/src/test/java/com/ani/taku_backend/init/PostInit.java
@@ -37,7 +37,7 @@ public class PostInit {
     @Autowired
     CategoryRepository categoryRepository;
 
-    @Test
+//    @Test
     void init() throws InterruptedException {
 
         int batchSize = 500;

--- a/src/test/java/com/ani/taku_backend/init/PostInit.java
+++ b/src/test/java/com/ani/taku_backend/init/PostInit.java
@@ -41,7 +41,7 @@ public class PostInit {
     void init() throws InterruptedException {
 
         int batchSize = 500;
-        int totalPosts = 10000;
+        int totalPosts = 1000;
         int threadCount = 4;
 
         List<User> allUser = userRepository.findAll();

--- a/src/test/java/com/ani/taku_backend/post/service/PostInteractionServiceTest.java
+++ b/src/test/java/com/ani/taku_backend/post/service/PostInteractionServiceTest.java
@@ -28,7 +28,7 @@ class PostInteractionServiceTest {
     @Autowired UserRepository userRepository;
 
     private static final int THREAD_COUNT = 10;  // 동시에 실행할 스레드 개수
-    private static final int LIKES_PER_USER = 10; // 한 유저당 좋아요를 누를 게시글 수
+    private static final int LIKES_PER_USER = 10; //4를 게시글 수
 
     @Test
     void postLikesTest() throws InterruptedException {


### PR DESCRIPTION
## Description
### [auth] 카카오 로그인 버그
- kakao 로그인 시도 시 DB에 가입된 회원의 정보 중 email이 null 일경우 서버 로그에서는 회원이 있다고하지만 계속 회원가입페이지로 리다이렉트 되는 현상을 해결

### [기타] @Test 주석 처리
- 더미 데이터 초기화 하는 코드들에 @Test 애노테이션을 제거

## Changes
### 카카오 로그인 관련
- OAuth2UserService에서 email로 로그인된 유저를 검증하던 로직을 각 OAuth별 제공되는 도메스틱 아이디로 수정

## Screenshots
### DB에 회원 데이터는 있지만 email 데이터는 없음(카카오, 구글)
![image](https://github.com/user-attachments/assets/651a9f2a-dccf-4d5b-b7cf-382e6e9712e6)

### 구글 로그인 성공 로그
- 로그 중  User : 도메스틱 ID 확인
![image](https://github.com/user-attachments/assets/a92d02f2-e829-4db1-9f5e-ffb359335144)


### 카카오 로그인 성공 로그
 - User : 도메스틱 ID 확인
![image](https://github.com/user-attachments/assets/be8bfdc2-32f0-451d-a8bc-fe8fbcee9db4)
