### PR TITLE
[CHAT] DTO에서 비즈니스 로직 분리 및 도메인 책임 강화

### DIFF
--- a/src/main/java/com/ani/taku_backend/chatroom/domain/document/ChatRoomMetaInfo.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/domain/document/ChatRoomMetaInfo.java
@@ -214,6 +214,26 @@ public class ChatRoomMetaInfo {
     }
 
     /**
+     * 참여자의 활성화 상태를 변경합니다.
+     * 참여자 검증 및 상태 변경을 캡슐화합니다.
+     *
+     * @param userId 상태를 변경할 사용자 ID
+     * @param active 활성화 여부 (true: 활성화, false: 비활성화)
+     * @throws DuckwhoException 유효하지 않은 사용자인 경우 발생
+     */
+    public void updateParticipantStatus(Long userId, boolean active) {
+        if (!this.participants.containsUser(userId)) {
+            throw new DuckwhoException(ErrorCode.INVALID_CHAT_USER);
+        }
+        
+        if (active) {
+            this.participants.getInfo().get(userId).activate();
+        } else {
+            this.participants.getInfo().get(userId).deactivate();
+        }
+    }
+
+    /**
      * 현재 채팅방의 마지막 메시지를 가져옵니다.
      * @return 마지막 메시지 또는 비어있을 경우 null
      */

--- a/src/main/java/com/ani/taku_backend/chatroom/domain/document/Participants.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/domain/document/Participants.java
@@ -10,6 +10,7 @@ import java.util.Map;
  */
 @Getter
 public class Participants {
+
     private Map<Long, ParticipantInfo> info = new ConcurrentHashMap<>();
 
     public Participants() {

--- a/src/main/java/com/ani/taku_backend/chatroom/domain/document/Participants.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/domain/document/Participants.java
@@ -86,4 +86,19 @@ public class Participants {
         return (role == JangterChatRole.BUYER && participant.isBuyer()) ||
                (role == JangterChatRole.SELLER && participant.isSeller());
     }
+
+    /**
+     * 특정 사용자가 활성 상태인지 확인합니다.
+     *
+     * @param userId 확인할 사용자 ID
+     * @return 사용자가 활성 상태면 true, 그렇지 않으면 false
+     */
+    public boolean isParticipantActive(Long userId) {
+        ParticipantInfo participant = info.get(userId);
+        if (participant == null) {
+            return false;
+        }
+        
+        return participant.isActive();
+    }
 }

--- a/src/main/java/com/ani/taku_backend/chatroom/domain/entity/ChatRoom.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/domain/entity/ChatRoom.java
@@ -16,6 +16,8 @@ import java.util.Set;
 import java.util.LinkedHashSet;
 import java.util.stream.Collectors;
 import java.util.Objects;
+import com.ani.taku_backend.common.exception.DuckwhoException;
+import com.ani.taku_backend.common.exception.ErrorCode;
 
 /**
  * 채팅방 정보를 나타내는 엔티티입니다.
@@ -155,6 +157,38 @@ public class ChatRoom extends BaseTimeEntity {
     }
 
     /**
+     * 채팅방의 상태를 검증합니다.
+     * 비활성화된 채팅방이거나 유효하지 않은 경우 예외를 발생시킵니다.
+     * 
+     * @throws DuckwhoException 채팅방이 비활성 상태이거나 유효하지 않은 경우
+     */
+    public void validateStatus() {
+        if (!isValid()) {
+            throw new DuckwhoException(ErrorCode.INACTIVE_CHAT_ROOM);
+        }
+        
+        if (this.status != ChatRoomStatus.ACTIVE) {
+            throw new DuckwhoException(ErrorCode.INACTIVE_CHAT_ROOM);
+        }
+    }
+    
+    /**
+     * 사용자가 채팅방에 참여 가능한지 검증합니다.
+     * 해당 사용자가 채팅방 참여자가 아닌 경우 예외를 발생시킵니다.
+     * 
+     * @param userId 검증할 사용자 ID
+     * @throws DuckwhoException 사용자가 참여자가 아닌 경우
+     */
+    public void validateUserAccess(Long userId) {
+        boolean isParticipant = this.participants.stream()
+                .anyMatch(p -> p.isUser(userId));
+                
+        if (!isParticipant) {
+            throw new DuckwhoException(ErrorCode.UNAUTHORIZED_ACCESS);
+        }
+    }
+
+    /**
      * 여러 채팅방에서 채팅방 ID 목록을 추출합니다.
      * 
      * @param chatRooms 채팅방 목록
@@ -180,5 +214,31 @@ public class ChatRoom extends BaseTimeEntity {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * 특정 사용자가 특정 역할로 참여하고 있는지 확인합니다.
+     * 
+     * @param userId 확인할 사용자 ID
+     * @param role 확인할 역할
+     * @return 해당 사용자가 지정된 역할로 참여하고 있으면 true
+     */
+    public boolean hasUserWithRole(Long userId, JangterChatRole role) {
+        return this.participants.stream()
+                .anyMatch(participant -> 
+                        participant.isUser(userId) && 
+                        participant.getRole() == role);
+    }
+    
+    /**
+     * 활성 상태의 채팅방 목록에서 특정 사용자가 구매자로 참여하고 있는 채팅방이 있는지 확인합니다.
+     * 
+     * @param chatRooms 확인할 채팅방 목록
+     * @param buyerId 확인할 구매자 ID
+     * @return 구매자로 참여중인 활성 채팅방이 있으면 true
+     */
+    public static boolean hasActiveBuyerInRooms(List<ChatRoom> chatRooms, Long buyerId) {
+        return chatRooms.stream()
+                .filter(room -> room.getStatus() == ChatRoomStatus.ACTIVE)
+                .anyMatch(room -> room.hasUserWithRole(buyerId, JangterChatRole.BUYER));
+    }
 
 }

--- a/src/main/java/com/ani/taku_backend/chatroom/domain/repository/ChatRoomRepositoryCustom.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/domain/repository/ChatRoomRepositoryCustom.java
@@ -14,11 +14,6 @@ import org.springframework.data.domain.Slice;
 public interface ChatRoomRepositoryCustom {
     
     /**
-     * 사용자의 채팅방 목록을 모든 연관 엔티티와 함께 한 번에 조회합니다.
-     */
-    List<ChatRoom> findChatRoomsWithParticipantsAndUsers(Long userId, ChatRoomStatus status);
-    
-    /**
      * 사용자의 특정 역할 채팅방 목록을 모든 연관 엔티티와 함께 한 번에 조회합니다.
      */
     List<ChatRoom> findChatRoomsByUserIdAndRole(Long userId, JangterChatRole role, ChatRoomStatus status);

--- a/src/main/java/com/ani/taku_backend/chatroom/domain/repository/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/domain/repository/ChatRoomRepositoryImpl.java
@@ -134,7 +134,6 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
         QChatRoomParticipant participant = QChatRoomParticipant.chatRoomParticipant;
         QUser user = QUser.user;
 
-        // 첫 번째 쿼리로 사용자가 참여한 채팅방 ID 목록을 가져옵니다
         List<Long> chatRoomIds = queryFactory
                 .select(participant.chatRoom.id)
                 .from(participant)
@@ -152,7 +151,6 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
             return new SliceImpl<>(Collections.emptyList(), pageable, false);
         }
 
-        // 두 번째 쿼리로 상세 정보를 한 번에 가져옵니다
         List<ChatRoom> results = queryFactory
                 .selectFrom(chatRoom)
                 .distinct()
@@ -163,11 +161,9 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
                 .fetch();
 
         log.debug("페이징 조회된 채팅방 수: {}", results.size());
-        
-        // 페이지 사이즈보다 많은 결과가 있는지 확인하여 hasNext 결정
+
         boolean hasNext = results.size() > pageable.getPageSize();
-        
-        // 만약 다음 페이지가 있다면 마지막 요소는 제거
+
         if (hasNext) {
             results = results.subList(0, pageable.getPageSize());
         }

--- a/src/main/java/com/ani/taku_backend/chatroom/domain/repository/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/domain/repository/ChatRoomRepositoryImpl.java
@@ -32,40 +32,6 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
         this.queryFactory = new JPAQueryFactory(entityManager);
     }
 
-    @Override
-    public List<ChatRoom> findChatRoomsWithParticipantsAndUsers(Long userId, ChatRoomStatus status) {
-        log.debug("사용자 ID: {}, 상태: {}로 채팅방 조회 시작", userId, status);
-        
-        QChatRoom chatRoom = QChatRoom.chatRoom;
-        QChatRoomParticipant participant = QChatRoomParticipant.chatRoomParticipant;
-        QUser user = QUser.user;
-
-        List<Long> chatRoomIds = queryFactory
-                .select(participant.chatRoom.id)
-                .from(participant)
-                .where(
-                    participant.user.userId.eq(userId),
-                    participant.chatRoom.status.eq(status)
-                )
-                .fetch();
-
-        if (chatRoomIds.isEmpty()) {
-            log.debug("사용자가 참여한 채팅방이 없습니다: userId={}", userId);
-            return Collections.emptyList();
-        }
-
-        List<ChatRoom> results = queryFactory
-                .selectFrom(chatRoom)
-                .distinct()
-                .leftJoin(chatRoom.participants, participant).fetchJoin()
-                .leftJoin(participant.user, user).fetchJoin()
-                .where(chatRoom.id.in(chatRoomIds))
-                .fetch();
-
-        log.debug("조회된 채팅방 수: {}", results.size());
-        
-        return results;
-    }
 
     @Override
     public List<ChatRoom> findChatRoomsByUserIdAndRole(Long userId, JangterChatRole role, ChatRoomStatus status) {

--- a/src/main/java/com/ani/taku_backend/chatroom/domain/vo/ChatRoomMessages.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/domain/vo/ChatRoomMessages.java
@@ -3,6 +3,8 @@ package com.ani.taku_backend.chatroom.domain.vo;
 import com.ani.taku_backend.chatroom.domain.document.ChatMessage;
 import com.ani.taku_backend.chatroom.domain.document.ChatRoomMetaInfo;
 import com.ani.taku_backend.chatroom.contansts.MessageConstants;
+import com.ani.taku_backend.chatroom.domain.entity.ChatRoom;
+import com.ani.taku_backend.chatroom.dto.response.ChatMessageResponseDTO;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -86,6 +88,38 @@ public class ChatRoomMessages {
             .map(MessageItem::getMessage)
             .filter(Objects::nonNull)
             .findFirst();
+    }
+
+    /**
+     * 채팅방의 마지막 메시지를 DTO로 변환.
+     *
+     * @param chatRoom 채팅방 객체
+     * @param metaInfo 채팅방 메타 정보
+     * @param users 채팅방 사용자 정보
+     * @return 마지막 메시지 DTO, 없거나 조건을 만족하지 않으면 null
+     */
+    public ChatMessageResponseDTO createLastMessageDTO(
+            ChatRoom chatRoom,
+            ChatRoomMetaInfo metaInfo,
+            ChatRoomUsers users) {
+            
+        Long chatRoomId = chatRoom.getId();
+        if (chatRoomId == null) {
+            return null;
+        }
+        
+        // 1. 마지막 메시지 조회 (현재 객체에서 먼저 찾고, 없으면 metaInfo에서 찾음)
+        return getLastMessage(chatRoomId)
+                .or(() -> Optional.ofNullable(metaInfo.getLastMessage()))
+                .filter(msg -> msg.getSenderId() != null)
+                .map(lastMessage -> {
+                    // 2. 발신자 이름 획득
+                    String senderName = users.getUserNicknameOrUnknown(lastMessage.getSenderId());
+                    
+                    // 3. DTO 생성 및 반환
+                    return ChatMessageResponseDTO.from(lastMessage, senderName, chatRoom.getWsRoomId());
+                })
+                .orElse(null);
     }
 
     public List<MessageItem> getItems() {

--- a/src/main/java/com/ani/taku_backend/chatroom/dto/response/ChatRoomCompositeDTO.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/dto/response/ChatRoomCompositeDTO.java
@@ -6,6 +6,7 @@ import com.ani.taku_backend.chatroom.domain.vo.ChatRoomMessages;
 import com.ani.taku_backend.chatroom.domain.vo.ChatRoomMetaInfos;
 import com.ani.taku_backend.chatroom.domain.vo.ChatRoomUsers;
 import com.ani.taku_backend.chatroom.domain.vo.UnreadMessageCounts;
+import com.ani.taku_backend.chatroom.mapper.ChatRoomDtoConverter;
 import lombok.Value;
 
 import java.util.List;
@@ -21,6 +22,22 @@ public class ChatRoomCompositeDTO {
     ChatRoomMessages lastMessages;
     UnreadMessageCounts unreadCounts;
     ChatRoomUsers users;
+    ChatRoomDtoConverter dtoConverter;
+
+    public ChatRoomCompositeDTO(
+            ChatRoomMetaInfos metaInfos,
+            ArticleImage articleImage,
+            ChatRoomMessages lastMessages,
+            UnreadMessageCounts unreadCounts,
+            ChatRoomUsers users,
+            ChatRoomDtoConverter dtoConverter) {
+        this.metaInfos = metaInfos;
+        this.articleImage = articleImage;
+        this.lastMessages = lastMessages;
+        this.unreadCounts = unreadCounts;
+        this.users = users;
+        this.dtoConverter = dtoConverter;
+    }
 
     public List<ChatRoomResponseDTO> toChatRoomResponseDTOs(List<ChatRoom> chatRooms) {
         return chatRooms.stream()
@@ -29,10 +46,9 @@ public class ChatRoomCompositeDTO {
                 .collect(java.util.stream.Collectors.toList());
     }
     
-
     public ChatRoomResponseDTO toChatRoomResponseDTO(ChatRoom room) {
         return metaInfos.getMetaInfo(room.getId())
-                .map(metaInfo -> ChatRoomResponseDTO.from(
+                .map(metaInfo -> dtoConverter.toResponseDto(
                         room,
                         metaInfo,
                         users,

--- a/src/main/java/com/ani/taku_backend/chatroom/dto/response/ChatRoomCompositeDTO.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/dto/response/ChatRoomCompositeDTO.java
@@ -6,7 +6,7 @@ import com.ani.taku_backend.chatroom.domain.vo.ChatRoomMessages;
 import com.ani.taku_backend.chatroom.domain.vo.ChatRoomMetaInfos;
 import com.ani.taku_backend.chatroom.domain.vo.ChatRoomUsers;
 import com.ani.taku_backend.chatroom.domain.vo.UnreadMessageCounts;
-import com.ani.taku_backend.chatroom.mapper.ChatRoomDtoConverter;
+import com.ani.taku_backend.chatroom.service.query.ChatRoomQueryService;
 import lombok.Value;
 
 import java.util.List;
@@ -22,7 +22,7 @@ public class ChatRoomCompositeDTO {
     ChatRoomMessages lastMessages;
     UnreadMessageCounts unreadCounts;
     ChatRoomUsers users;
-    ChatRoomDtoConverter dtoConverter;
+    ChatRoomQueryService chatRoomQueryService;
 
     public ChatRoomCompositeDTO(
             ChatRoomMetaInfos metaInfos,
@@ -30,13 +30,13 @@ public class ChatRoomCompositeDTO {
             ChatRoomMessages lastMessages,
             UnreadMessageCounts unreadCounts,
             ChatRoomUsers users,
-            ChatRoomDtoConverter dtoConverter) {
+            ChatRoomQueryService chatRoomQueryService) {
         this.metaInfos = metaInfos;
         this.articleImage = articleImage;
         this.lastMessages = lastMessages;
         this.unreadCounts = unreadCounts;
         this.users = users;
-        this.dtoConverter = dtoConverter;
+        this.chatRoomQueryService = chatRoomQueryService;
     }
 
     public List<ChatRoomResponseDTO> toChatRoomResponseDTOs(List<ChatRoom> chatRooms) {
@@ -48,7 +48,7 @@ public class ChatRoomCompositeDTO {
     
     public ChatRoomResponseDTO toChatRoomResponseDTO(ChatRoom room) {
         return metaInfos.getMetaInfo(room.getId())
-                .map(metaInfo -> dtoConverter.toResponseDto(
+                .map(metaInfo -> chatRoomQueryService.createChatRoomResponseDTO(
                         room,
                         metaInfo,
                         users,

--- a/src/main/java/com/ani/taku_backend/chatroom/dto/response/ChatRoomResponseDTO.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/dto/response/ChatRoomResponseDTO.java
@@ -1,23 +1,10 @@
 package com.ani.taku_backend.chatroom.dto.response;
 
-import com.ani.taku_backend.chatroom.contansts.MessageConstants;
-import com.ani.taku_backend.chatroom.domain.document.ChatMessage;
-import com.ani.taku_backend.chatroom.domain.document.ChatRoomMetaInfo;
-import com.ani.taku_backend.chatroom.domain.entity.ChatRoom;
-import com.ani.taku_backend.chatroom.domain.vo.ArticleImage;
-import com.ani.taku_backend.chatroom.domain.vo.ChatRoomMessages;
-import com.ani.taku_backend.chatroom.domain.vo.ChatRoomUsers;
-import com.ani.taku_backend.chatroom.domain.vo.UnreadMessageCounts;
-
-import com.ani.taku_backend.user.model.entity.User;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
 
 /**
  * 채팅방 정보를 응답하기 위한 DTO 클래스
@@ -25,8 +12,6 @@ import java.util.Optional;
 @Getter
 @ToString
 public class ChatRoomResponseDTO {
-
-    private static final Logger log = LoggerFactory.getLogger(ChatRoomResponseDTO.class);
 
     private final Long chatRoomId;
     private final String wsRoomId;
@@ -44,7 +29,7 @@ public class ChatRoomResponseDTO {
     private final String sellerProfileImageUrl;
 
     @Builder
-    private ChatRoomResponseDTO(
+    public ChatRoomResponseDTO(
             Long chatRoomId,
             String wsRoomId,
             Long articleId,
@@ -73,206 +58,5 @@ public class ChatRoomResponseDTO {
         this.unreadMessageCount = unreadMessageCount;
         this.buyerProfileImageUrl = buyerProfileImageUrl;
         this.sellerProfileImageUrl = sellerProfileImageUrl;
-    }
-
-    /**
-     * 채팅방과 관련 정보로부터 응답 DTO를 생성합니다.
-     * 단일 채팅방에 대한 DTO 생성을 위한 정적 팩토리 메서드입니다.
-     */
-    public static ChatRoomResponseDTO from(
-            ChatRoom chatRoom,
-            ChatRoomMetaInfo metaInfo,
-            ChatRoomUsers users,
-            ChatRoomMessages lastMessages,
-            UnreadMessageCounts unreadCounts,
-            ArticleImage articleImage) {
-        
-        if (chatRoom == null || metaInfo == null || !chatRoom.isValid()) {
-            return null;
-        }
-        
-        return new ResponseDTOBuilder(chatRoom)
-                .withMetaInfo(metaInfo)
-                .withUsers(users)
-                .withLastMessages(lastMessages)
-                .withUnreadCounts(unreadCounts)
-                .withArticleImages(articleImage)
-                .build();
-    }
-    
-    /**
-     * ChatRoomResponseDTO를 생성하기 위한 빌더 클래스
-     * 내부 클래스로 캡슐화하여 빌더 패턴의 사용을 제한합니다.
-     */
-    private static class ResponseDTOBuilder {
-        
-        private final ChatRoom chatRoom;
-        private ChatRoomMetaInfo metaInfo;
-        private ChatRoomUsers users;
-        private ChatRoomMessages lastMessages;
-        private UnreadMessageCounts unreadCounts;
-        private ArticleImage articleImage;
-        
-        private ResponseDTOBuilder(ChatRoom chatRoom) {
-            this.chatRoom = chatRoom;
-        }
-        
-        public ResponseDTOBuilder withMetaInfo(ChatRoomMetaInfo metaInfo) {
-            this.metaInfo = metaInfo;
-            return this;
-        }
-        
-        /**
-         * 사용자 정보 설정
-         */
-        public ResponseDTOBuilder withUsers(ChatRoomUsers users) {
-            this.users = users;
-            return this;
-        }
-        
-        /**
-         * 마지막 메시지 정보 설정
-         */
-        public ResponseDTOBuilder withLastMessages(ChatRoomMessages lastMessages) {
-            this.lastMessages = lastMessages;
-            return this;
-        }
-        
-        /**
-         * 읽지 않은 메시지 수 설정
-         */
-        public ResponseDTOBuilder withUnreadCounts(UnreadMessageCounts unreadCounts) {
-            this.unreadCounts = unreadCounts;
-            return this;
-        }
-        
-        /**
-         * 상품 이미지 정보 설정
-         */
-        public ResponseDTOBuilder withArticleImages(ArticleImage articleImage) {
-            this.articleImage = articleImage;
-            return this;
-        }
-
-        public ChatRoomResponseDTO build() {
-
-            if (chatRoom == null || metaInfo == null) {
-                return null;
-            }
-            
-            Long chatRoomId = chatRoom.getId();
-            User buyer = chatRoom.getBuyer();
-            User seller = chatRoom.getSeller();
-            
-            if (buyer == null && seller == null) {
-                return null;
-            }
-            
-            Long buyerId = buyer != null ? buyer.getUserId() : null;
-            Long sellerId = seller != null ? seller.getUserId() : null;
-            
-
-            String buyerNickname;
-            String sellerNickname;
-            String buyerProfileImg;
-            String sellerProfileImg;
-            
-            if (users != null) {
-                buyerNickname = buyerId != null ? users.getUserNicknameOrUnknown(buyerId) : MessageConstants.UNKNOWN_USER;
-                sellerNickname = sellerId != null ? users.getUserNicknameOrUnknown(sellerId) : MessageConstants.UNKNOWN_USER;
-                buyerProfileImg = buyerId != null ? users.getUserProfileImage(buyerId) : null;
-                sellerProfileImg = sellerId != null ? users.getUserProfileImage(sellerId) : null;
-            } else {
-                buyerNickname = buyer != null ? buyer.getNickname() : MessageConstants.UNKNOWN_USER;
-                sellerNickname = seller != null ? seller.getNickname() : MessageConstants.UNKNOWN_USER;
-                buyerProfileImg = buyer != null ? buyer.getProfileImg() : null;
-                sellerProfileImg = seller != null ? seller.getProfileImg() : null;
-            }
-            
-            // 마지막 메시지 처리
-            ChatMessageResponseDTO lastMessageDTO = createLastMessageDTO(chatRoomId);
-            
-            // 아티클 이미지 URL 처리
-            String articleImageUrl = getArticleImageUrl(chatRoom.getArticleId());
-            
-            // 읽지 않은 메시지 수 처리
-            Integer unreadCount = getUnreadCount(chatRoomId);
-            
-            return ChatRoomResponseDTO.builder()
-                    .chatRoomId(chatRoom.getId())
-                    .wsRoomId(chatRoom.getWsRoomId())
-                    .articleId(chatRoom.getArticleId())
-                    .buyerId(buyerId)
-                    .sellerId(sellerId)
-                    .buyerNickname(buyerNickname)
-                    .sellerNickname(sellerNickname)
-                    .lastMessage(lastMessageDTO)
-                    .createdAt(chatRoom.getCreatedAt())
-                    .updatedAt(chatRoom.getUpdatedAt())
-                    .articleImageUrl(articleImageUrl)
-                    .unreadMessageCount(unreadCount)
-                    .buyerProfileImageUrl(buyerProfileImg)
-                    .sellerProfileImageUrl(sellerProfileImg)
-                    .build();
-        }
-        
-
-        private ChatMessageResponseDTO createLastMessageDTO(Long chatRoomId) {
-            if (chatRoomId == null) {
-                return null;
-            }
-            
-            Optional<ChatMessage> messageOpt;
-            try {
-                messageOpt = lastMessages != null 
-                    ? lastMessages.getLastMessage(chatRoomId) 
-                    : Optional.ofNullable(metaInfo != null ? metaInfo.getLastMessage() : null);
-            } catch (Exception e) {
-                log.warn("마지막 메시지 조회 중 오류 발생: chatRoomId={}, error={}", chatRoomId, e.getMessage());
-                return null;
-            }
-            
-            if (messageOpt.isEmpty()) {
-                return null;
-            }
-            
-            ChatMessage lastMessage = messageOpt.get();
-            if (lastMessage == null || lastMessage.getSenderId() == null) {
-                return null;
-            }
-            
-            String senderName = users != null 
-                ? users.getUserNicknameOrUnknown(lastMessage.getSenderId())
-                : MessageConstants.UNKNOWN_USER;
-            
-            try {
-                return ChatMessageResponseDTO.from(lastMessage, senderName, chatRoom.getWsRoomId());
-            } catch (Exception e) {
-                log.warn("메시지 DTO 생성 중 오류 발생: chatRoomId={}, error={}", chatRoomId, e.getMessage());
-                return null;
-            }
-        }
-        
-        /**
-         * 상품 이미지 URL을 가져옵니다.
-         */
-        private String getArticleImageUrl(Long articleId) {
-            if (articleId == null || articleImage == null) {
-                return null;
-            }
-            try {
-                return articleImage.getImageUrl(articleId);
-            } catch (Exception e) {
-                log.warn("상품 이미지 조회 중 오류 발생: articleId={}, error={}", articleId, e.getMessage());
-                return null;
-            }
-        }
-        
-        /**
-         * 읽지 않은 메시지 수를 가져옵니다.
-         */
-        private Integer getUnreadCount(Long chatRoomId) {
-            return unreadCounts != null ? unreadCounts.getUnreadCount(chatRoomId) : 0;
-        }
     }
 }

--- a/src/main/java/com/ani/taku_backend/chatroom/mapper/ChatRoomDtoConverter.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/mapper/ChatRoomDtoConverter.java
@@ -1,7 +1,5 @@
 package com.ani.taku_backend.chatroom.mapper;
 
-import com.ani.taku_backend.chatroom.contansts.MessageConstants;
-import com.ani.taku_backend.chatroom.domain.document.ChatMessage;
 import com.ani.taku_backend.chatroom.domain.document.ChatRoomMetaInfo;
 import com.ani.taku_backend.chatroom.domain.entity.ChatRoom;
 import com.ani.taku_backend.chatroom.domain.vo.ArticleImage;
@@ -11,72 +9,36 @@ import com.ani.taku_backend.chatroom.domain.vo.UnreadMessageCounts;
 import com.ani.taku_backend.chatroom.dto.response.ChatMessageResponseDTO;
 import com.ani.taku_backend.chatroom.dto.response.ChatRoomResponseDTO;
 import com.ani.taku_backend.user.model.entity.User;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-
-import java.util.Optional;
 
 /**
  * 채팅방 도메인 객체를 DTO로 변환하는 컨버터 클래스
- * 복잡한 매핑 로직을 캡슐화하여 DTO에서 비즈니스 로직을 분리합니다.
  */
-@Slf4j
 @Component
 public class ChatRoomDtoConverter {
 
-    /**
-     * 채팅방과 관련 정보로부터 응답 DTO를 생성합니다.
-     */
     public ChatRoomResponseDTO toResponseDto(
             ChatRoom chatRoom,
             ChatRoomMetaInfo metaInfo,
             ChatRoomUsers users,
             ChatRoomMessages lastMessages,
             UnreadMessageCounts unreadCounts,
-            ArticleImage articleImage) {
-
-        if (chatRoom == null || metaInfo == null || !chatRoom.isValid()) {
-            return null;
-        }
-
-        Long chatRoomId = chatRoom.getId();
+            ArticleImage articleImage,
+            ChatMessageResponseDTO lastMessageDTO,
+            String articleImageUrl,
+            Integer unreadCount) {
+        
         User buyer = chatRoom.getBuyer();
         User seller = chatRoom.getSeller();
-
-        if (buyer == null && seller == null) {
-            return null;
-        }
-
+        
         Long buyerId = buyer != null ? buyer.getUserId() : null;
         Long sellerId = seller != null ? seller.getUserId() : null;
-
-        // 참여자 정보 처리
-        String buyerNickname;
-        String sellerNickname;
-        String buyerProfileImg;
-        String sellerProfileImg;
-
-        if (users != null) {
-            buyerNickname = buyerId != null ? users.getUserNicknameOrUnknown(buyerId) : MessageConstants.UNKNOWN_USER;
-            sellerNickname = sellerId != null ? users.getUserNicknameOrUnknown(sellerId) : MessageConstants.UNKNOWN_USER;
-            buyerProfileImg = buyerId != null ? users.getUserProfileImage(buyerId) : null;
-            sellerProfileImg = sellerId != null ? users.getUserProfileImage(sellerId) : null;
-        } else {
-            buyerNickname = buyer != null ? buyer.getNickname() : MessageConstants.UNKNOWN_USER;
-            sellerNickname = seller != null ? seller.getNickname() : MessageConstants.UNKNOWN_USER;
-            buyerProfileImg = buyer != null ? buyer.getProfileImg() : null;
-            sellerProfileImg = seller != null ? seller.getProfileImg() : null;
-        }
-
-        // 마지막 메시지 처리
-        ChatMessageResponseDTO lastMessageDTO = createLastMessageDTO(chatRoom, chatRoomId, lastMessages, metaInfo, users);
-
-        // 아티클 이미지 URL 처리
-        String articleImageUrl = getArticleImageUrl(chatRoom.getArticleId(), articleImage);
-
-        // 읽지 않은 메시지 수 처리
-        Integer unreadCount = getUnreadCount(chatRoomId, unreadCounts);
-
+        
+        String buyerNickname = users.getUserNicknameOrUnknown(buyerId);
+        String sellerNickname = users.getUserNicknameOrUnknown(sellerId);
+        String buyerProfileImg = users.getUserProfileImage(buyerId);
+        String sellerProfileImg = users.getUserProfileImage(sellerId);
+        
         return ChatRoomResponseDTO.builder()
                 .chatRoomId(chatRoom.getId())
                 .wsRoomId(chatRoom.getWsRoomId())
@@ -93,72 +55,5 @@ public class ChatRoomDtoConverter {
                 .buyerProfileImageUrl(buyerProfileImg)
                 .sellerProfileImageUrl(sellerProfileImg)
                 .build();
-    }
-
-    /**
-     * 마지막 메시지 DTO를 생성합니다.
-     */
-    private ChatMessageResponseDTO createLastMessageDTO(
-            ChatRoom chatRoom,
-            Long chatRoomId,
-            ChatRoomMessages lastMessages,
-            ChatRoomMetaInfo metaInfo,
-            ChatRoomUsers users) {
-
-        if (chatRoomId == null) {
-            return null;
-        }
-
-        Optional<ChatMessage> messageOpt;
-        try {
-            messageOpt = lastMessages != null
-                    ? lastMessages.getLastMessage(chatRoomId)
-                    : Optional.ofNullable(metaInfo != null ? metaInfo.getLastMessage() : null);
-        } catch (Exception e) {
-            log.warn("마지막 메시지 조회 중 오류 발생: chatRoomId={}, error={}", chatRoomId, e.getMessage());
-            return null;
-        }
-
-        if (messageOpt.isEmpty()) {
-            return null;
-        }
-
-        ChatMessage lastMessage = messageOpt.get();
-        if (lastMessage == null || lastMessage.getSenderId() == null) {
-            return null;
-        }
-
-        String senderName = users != null
-                ? users.getUserNicknameOrUnknown(lastMessage.getSenderId())
-                : MessageConstants.UNKNOWN_USER;
-
-        try {
-            return ChatMessageResponseDTO.from(lastMessage, senderName, chatRoom.getWsRoomId());
-        } catch (Exception e) {
-            log.warn("메시지 DTO 생성 중 오류 발생: chatRoomId={}, error={}", chatRoomId, e.getMessage());
-            return null;
-        }
-    }
-
-    /**
-     * 상품 이미지 URL을 가져옵니다.
-     */
-    private String getArticleImageUrl(Long articleId, ArticleImage articleImage) {
-        if (articleId == null || articleImage == null) {
-            return null;
-        }
-        try {
-            return articleImage.getImageUrl(articleId);
-        } catch (Exception e) {
-            log.warn("상품 이미지 조회 중 오류 발생: articleId={}, error={}", articleId, e.getMessage());
-            return null;
-        }
-    }
-
-    /**
-     * 읽지 않은 메시지 수를 가져옵니다.
-     */
-    private Integer getUnreadCount(Long chatRoomId, UnreadMessageCounts unreadCounts) {
-        return unreadCounts != null ? unreadCounts.getUnreadCount(chatRoomId) : 0;
     }
 }

--- a/src/main/java/com/ani/taku_backend/chatroom/mapper/ChatRoomDtoConverter.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/mapper/ChatRoomDtoConverter.java
@@ -1,0 +1,164 @@
+package com.ani.taku_backend.chatroom.mapper;
+
+import com.ani.taku_backend.chatroom.contansts.MessageConstants;
+import com.ani.taku_backend.chatroom.domain.document.ChatMessage;
+import com.ani.taku_backend.chatroom.domain.document.ChatRoomMetaInfo;
+import com.ani.taku_backend.chatroom.domain.entity.ChatRoom;
+import com.ani.taku_backend.chatroom.domain.vo.ArticleImage;
+import com.ani.taku_backend.chatroom.domain.vo.ChatRoomMessages;
+import com.ani.taku_backend.chatroom.domain.vo.ChatRoomUsers;
+import com.ani.taku_backend.chatroom.domain.vo.UnreadMessageCounts;
+import com.ani.taku_backend.chatroom.dto.response.ChatMessageResponseDTO;
+import com.ani.taku_backend.chatroom.dto.response.ChatRoomResponseDTO;
+import com.ani.taku_backend.user.model.entity.User;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+/**
+ * 채팅방 도메인 객체를 DTO로 변환하는 컨버터 클래스
+ * 복잡한 매핑 로직을 캡슐화하여 DTO에서 비즈니스 로직을 분리합니다.
+ */
+@Slf4j
+@Component
+public class ChatRoomDtoConverter {
+
+    /**
+     * 채팅방과 관련 정보로부터 응답 DTO를 생성합니다.
+     */
+    public ChatRoomResponseDTO toResponseDto(
+            ChatRoom chatRoom,
+            ChatRoomMetaInfo metaInfo,
+            ChatRoomUsers users,
+            ChatRoomMessages lastMessages,
+            UnreadMessageCounts unreadCounts,
+            ArticleImage articleImage) {
+
+        if (chatRoom == null || metaInfo == null || !chatRoom.isValid()) {
+            return null;
+        }
+
+        Long chatRoomId = chatRoom.getId();
+        User buyer = chatRoom.getBuyer();
+        User seller = chatRoom.getSeller();
+
+        if (buyer == null && seller == null) {
+            return null;
+        }
+
+        Long buyerId = buyer != null ? buyer.getUserId() : null;
+        Long sellerId = seller != null ? seller.getUserId() : null;
+
+        // 참여자 정보 처리
+        String buyerNickname;
+        String sellerNickname;
+        String buyerProfileImg;
+        String sellerProfileImg;
+
+        if (users != null) {
+            buyerNickname = buyerId != null ? users.getUserNicknameOrUnknown(buyerId) : MessageConstants.UNKNOWN_USER;
+            sellerNickname = sellerId != null ? users.getUserNicknameOrUnknown(sellerId) : MessageConstants.UNKNOWN_USER;
+            buyerProfileImg = buyerId != null ? users.getUserProfileImage(buyerId) : null;
+            sellerProfileImg = sellerId != null ? users.getUserProfileImage(sellerId) : null;
+        } else {
+            buyerNickname = buyer != null ? buyer.getNickname() : MessageConstants.UNKNOWN_USER;
+            sellerNickname = seller != null ? seller.getNickname() : MessageConstants.UNKNOWN_USER;
+            buyerProfileImg = buyer != null ? buyer.getProfileImg() : null;
+            sellerProfileImg = seller != null ? seller.getProfileImg() : null;
+        }
+
+        // 마지막 메시지 처리
+        ChatMessageResponseDTO lastMessageDTO = createLastMessageDTO(chatRoom, chatRoomId, lastMessages, metaInfo, users);
+
+        // 아티클 이미지 URL 처리
+        String articleImageUrl = getArticleImageUrl(chatRoom.getArticleId(), articleImage);
+
+        // 읽지 않은 메시지 수 처리
+        Integer unreadCount = getUnreadCount(chatRoomId, unreadCounts);
+
+        return ChatRoomResponseDTO.builder()
+                .chatRoomId(chatRoom.getId())
+                .wsRoomId(chatRoom.getWsRoomId())
+                .articleId(chatRoom.getArticleId())
+                .buyerId(buyerId)
+                .sellerId(sellerId)
+                .buyerNickname(buyerNickname)
+                .sellerNickname(sellerNickname)
+                .lastMessage(lastMessageDTO)
+                .createdAt(chatRoom.getCreatedAt())
+                .updatedAt(chatRoom.getUpdatedAt())
+                .articleImageUrl(articleImageUrl)
+                .unreadMessageCount(unreadCount)
+                .buyerProfileImageUrl(buyerProfileImg)
+                .sellerProfileImageUrl(sellerProfileImg)
+                .build();
+    }
+
+    /**
+     * 마지막 메시지 DTO를 생성합니다.
+     */
+    private ChatMessageResponseDTO createLastMessageDTO(
+            ChatRoom chatRoom,
+            Long chatRoomId,
+            ChatRoomMessages lastMessages,
+            ChatRoomMetaInfo metaInfo,
+            ChatRoomUsers users) {
+
+        if (chatRoomId == null) {
+            return null;
+        }
+
+        Optional<ChatMessage> messageOpt;
+        try {
+            messageOpt = lastMessages != null
+                    ? lastMessages.getLastMessage(chatRoomId)
+                    : Optional.ofNullable(metaInfo != null ? metaInfo.getLastMessage() : null);
+        } catch (Exception e) {
+            log.warn("마지막 메시지 조회 중 오류 발생: chatRoomId={}, error={}", chatRoomId, e.getMessage());
+            return null;
+        }
+
+        if (messageOpt.isEmpty()) {
+            return null;
+        }
+
+        ChatMessage lastMessage = messageOpt.get();
+        if (lastMessage == null || lastMessage.getSenderId() == null) {
+            return null;
+        }
+
+        String senderName = users != null
+                ? users.getUserNicknameOrUnknown(lastMessage.getSenderId())
+                : MessageConstants.UNKNOWN_USER;
+
+        try {
+            return ChatMessageResponseDTO.from(lastMessage, senderName, chatRoom.getWsRoomId());
+        } catch (Exception e) {
+            log.warn("메시지 DTO 생성 중 오류 발생: chatRoomId={}, error={}", chatRoomId, e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * 상품 이미지 URL을 가져옵니다.
+     */
+    private String getArticleImageUrl(Long articleId, ArticleImage articleImage) {
+        if (articleId == null || articleImage == null) {
+            return null;
+        }
+        try {
+            return articleImage.getImageUrl(articleId);
+        } catch (Exception e) {
+            log.warn("상품 이미지 조회 중 오류 발생: articleId={}, error={}", articleId, e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * 읽지 않은 메시지 수를 가져옵니다.
+     */
+    private Integer getUnreadCount(Long chatRoomId, UnreadMessageCounts unreadCounts) {
+        return unreadCounts != null ? unreadCounts.getUnreadCount(chatRoomId) : 0;
+    }
+}

--- a/src/main/java/com/ani/taku_backend/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/service/ChatRoomService.java
@@ -40,6 +40,17 @@ public class ChatRoomService {
     }
     
     /**
+     * 사용자의 모든 채팅방 목록을 조회합니다.
+     * 
+     * @param userId 사용자 ID
+     * @return 채팅방 응답 DTO 목록
+     */
+    @Transactional(readOnly = true)
+    public List<ChatRoomResponseDTO> findChatRoomList(Long userId) {
+        return queryService.findChatRoomList(userId);
+    }
+    
+    /**
      * 사용자의 채팅방 목록을 페이징하여 조회합니다(무한 스크롤).
      * 
      * @param userId 사용자 ID

--- a/src/main/java/com/ani/taku_backend/chatroom/service/command/ChatRoomCommandService.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/service/command/ChatRoomCommandService.java
@@ -12,6 +12,7 @@ import com.ani.taku_backend.chatroom.domain.vo.ArticleImage;
 import com.ani.taku_backend.chatroom.domain.vo.ChatRoomMessages;
 import com.ani.taku_backend.chatroom.domain.vo.ChatRoomUsers;
 import com.ani.taku_backend.chatroom.domain.vo.UnreadMessageCounts;
+import com.ani.taku_backend.chatroom.mapper.ChatRoomDtoConverter;
 import com.ani.taku_backend.common.exception.DuckwhoException;
 import com.ani.taku_backend.common.exception.ErrorCode;
 import com.ani.taku_backend.jangter.model.dto.ProductImageDTO;
@@ -43,6 +44,7 @@ public class ChatRoomCommandService {
     private final ChatRoomMetaRepository chatRoomMetaRepository;
     private final DuckuJangterRepository duckuJangterRepository;
     private final UserRepository userRepository;
+    private final ChatRoomDtoConverter chatRoomDtoConverter;
 
 
     /**
@@ -142,16 +144,16 @@ public class ChatRoomCommandService {
         ArticleImage articleImage = ArticleImage.fromProductImageDTOs(productImages);
 
         ChatRoomMessages lastMessages = ChatRoomMessages.empty();
-        
+
         // 신규 채팅방은 읽지 않은 메시지가 없음
         UnreadMessageCounts unreadCounts = UnreadMessageCounts.of(
-                savedRoom.getId(), 
+                savedRoom.getId(),
                 0
         );
 
         ChatRoomUsers users = ChatRoomUsers.of(buyer, seller);
-        
-        return ChatRoomResponseDTO.from(
+
+        return chatRoomDtoConverter.toResponseDto(
                 savedRoom,
                 metaInfo,
                 users,

--- a/src/main/java/com/ani/taku_backend/chatroom/service/command/ChatRoomCommandService.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/service/command/ChatRoomCommandService.java
@@ -15,9 +15,7 @@ import com.ani.taku_backend.chatroom.domain.vo.UnreadMessageCounts;
 import com.ani.taku_backend.chatroom.mapper.ChatRoomDtoConverter;
 import com.ani.taku_backend.common.exception.DuckwhoException;
 import com.ani.taku_backend.common.exception.ErrorCode;
-import com.ani.taku_backend.jangter.model.dto.ProductImageDTO;
 import com.ani.taku_backend.jangter.model.entity.DuckuJangter;
-import com.ani.taku_backend.jangter.model.enums.ProductStatus;
 import com.ani.taku_backend.jangter.repository.DuckuJangterRepository;
 import com.ani.taku_backend.user.model.entity.User;
 import com.ani.taku_backend.user.repository.UserRepository;
@@ -57,11 +55,13 @@ public class ChatRoomCommandService {
      */
     public ChatRoomResponseDTO createChatRoom(ChatRoomRequestDTO requestDto) {
 
-        DuckuJangter product = findAndValidateProduct(requestDto.articleId());
+        DuckuJangter product = findProduct(requestDto.articleId());
+        
+        // 도메인 객체의 검증 메서드 호출
+        product.validateForChatRoom();
+        product.validateDifferentUsers(requestDto.buyerId());
 
         Long sellerId = product.getUser().getUserId();
-
-        validateDifferentUsers(sellerId, requestDto.buyerId());
 
         validateNewChatRoom(requestDto);
 
@@ -74,7 +74,14 @@ public class ChatRoomCommandService {
 
         ChatRoomMetaInfo metaInfo = createAndSaveChatRoomMetaInfo(savedRoom.getId(), requestDto.buyerId(), sellerId);
 
-        return createChatRoomResponseDTO(savedRoom, metaInfo, buyer, seller, requestDto.articleId());
+        return chatRoomQueryService.createChatRoomResponseDTO(
+                savedRoom,
+                metaInfo,
+                ChatRoomUsers.of(buyer, seller),
+                ChatRoomMessages.empty(),
+                UnreadMessageCounts.of(savedRoom.getId(), 0),
+                ArticleImage.fromProductImageDTOs(duckuJangterRepository.findProductImagesById(List.of(requestDto.articleId())))
+        );
     }
 
     /**
@@ -98,28 +105,13 @@ public class ChatRoomCommandService {
     }
 
     /**
-     * 상품을 조회하고 유효성을 검증합니다.
+     * 상품을 조회합니다.
      */
-    private DuckuJangter findAndValidateProduct(Long articleId) {
-        DuckuJangter product = duckuJangterRepository.findById(articleId)
+    private DuckuJangter findProduct(Long articleId) {
+        return duckuJangterRepository.findById(articleId)
                 .orElseThrow(() -> new DuckwhoException(ErrorCode.NOT_FOUND_POST));
-        
-        // 게시글 상태 확인 (판매중인 상태인지)
-        if (product.getStatus() != ProductStatus.FOR_SALE) {
-            throw new DuckwhoException(ErrorCode.INVALID_PRODUCT_STATUS);
-        }
-        
-        return product;
     }
 
-    /**
-     * 구매자와 판매자가 다른 사용자인지 검증합니다.
-     */
-    private void validateDifferentUsers(Long sellerId, Long buyerId) {
-        if (sellerId.equals(buyerId)) {
-            throw new DuckwhoException(ErrorCode.INVALID_CHAT_USER);
-        }
-    }
 
     /**
      * 사용자를 조회합니다.
@@ -139,54 +131,22 @@ public class ChatRoomCommandService {
         return chatRoomMetaRepository.save(metaInfo);
     }
 
-
-    private ChatRoomResponseDTO createChatRoomResponseDTO(
-            ChatRoom savedRoom, ChatRoomMetaInfo metaInfo, User buyer, User seller, Long articleId) {
-
-        List<ProductImageDTO> productImages = duckuJangterRepository.findProductImagesById(List.of(articleId));
-        ArticleImage articleImage = ArticleImage.fromProductImageDTOs(productImages);
-
-        ChatRoomMessages lastMessages = ChatRoomMessages.empty();
-
-        // 신규 채팅방은 읽지 않은 메시지가 없음
-        UnreadMessageCounts unreadCounts = UnreadMessageCounts.of(
-                savedRoom.getId(),
-                0
-        );
-
-        ChatRoomUsers users = ChatRoomUsers.of(buyer, seller);
-
-        return chatRoomQueryService.createChatRoomResponseDTO(
-                savedRoom,
-                metaInfo,
-                users,
-                lastMessages,
-                unreadCounts,
-                articleImage
-        );
-    }
-
-
     /**
      * 중복 채팅방 생성을 방지하기 위한 검증 로직
      */
     private void validateNewChatRoom(ChatRoomRequestDTO requestDto) {
+        // 1. 상품에 대한 모든 채팅방 조회
         List<ChatRoom> chatRooms = chatRoomRepository.findByArticleId(requestDto.articleId());
         if (chatRooms.isEmpty()) {
             return;
         }
 
-        boolean hasExistingBuyer = chatRooms.stream()
-                .filter(room -> room.getStatus() == ChatRoomStatus.ACTIVE)
-                .flatMap(room -> room.getParticipants().stream())
-                .anyMatch(participant ->
-                        participant.isUser(requestDto.buyerId()) &&
-                        participant.isBuyer());
-
-        if (hasExistingBuyer) {
+        // 2. 활성 채팅방에 구매자로 참여 중인지 확인
+        if (ChatRoom.hasActiveBuyerInRooms(chatRooms, requestDto.buyerId())) {
             throw new DuckwhoException(ErrorCode.DUPLICATE_CHAT_ROOM);
         }
 
+        // 3. 메타 정보에서도 역할 확인 (모든 상태의 채팅방 고려)
         List<Long> chatRoomIds = chatRooms.stream()
                 .map(ChatRoom::getId)
                 .toList();

--- a/src/main/java/com/ani/taku_backend/chatroom/service/command/ChatRoomCommandService.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/service/command/ChatRoomCommandService.java
@@ -91,15 +91,7 @@ public class ChatRoomCommandService {
         ChatRoomMetaInfo metaInfo = chatRoomMetaRepository.findByChatRoomId(chatRoomId)
                 .orElseThrow(() -> new DuckwhoException(ErrorCode.CHAT_ROOM_NOT_FOUND));
 
-        if (!metaInfo.getParticipants().containsUser(userId)) {
-            throw new DuckwhoException(ErrorCode.INVALID_CHAT_USER);
-        }
-        
-        if (active) {
-            metaInfo.getParticipants().getInfo().get(userId).activate();
-        } else {
-            metaInfo.getParticipants().getInfo().get(userId).deactivate();
-        }
+        metaInfo.updateParticipantStatus(userId, active);
 
         chatRoomMetaRepository.save(metaInfo);
     }

--- a/src/main/java/com/ani/taku_backend/chatroom/service/command/ChatRoomCommandService.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/service/command/ChatRoomCommandService.java
@@ -21,6 +21,7 @@ import com.ani.taku_backend.jangter.model.enums.ProductStatus;
 import com.ani.taku_backend.jangter.repository.DuckuJangterRepository;
 import com.ani.taku_backend.user.model.entity.User;
 import com.ani.taku_backend.user.repository.UserRepository;
+import com.ani.taku_backend.chatroom.service.query.ChatRoomQueryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -45,6 +46,7 @@ public class ChatRoomCommandService {
     private final DuckuJangterRepository duckuJangterRepository;
     private final UserRepository userRepository;
     private final ChatRoomDtoConverter chatRoomDtoConverter;
+    private final ChatRoomQueryService chatRoomQueryService;
 
 
     /**
@@ -137,6 +139,7 @@ public class ChatRoomCommandService {
         return chatRoomMetaRepository.save(metaInfo);
     }
 
+
     private ChatRoomResponseDTO createChatRoomResponseDTO(
             ChatRoom savedRoom, ChatRoomMetaInfo metaInfo, User buyer, User seller, Long articleId) {
 
@@ -153,7 +156,7 @@ public class ChatRoomCommandService {
 
         ChatRoomUsers users = ChatRoomUsers.of(buyer, seller);
 
-        return chatRoomDtoConverter.toResponseDto(
+        return chatRoomQueryService.createChatRoomResponseDTO(
                 savedRoom,
                 metaInfo,
                 users,
@@ -162,6 +165,7 @@ public class ChatRoomCommandService {
                 articleImage
         );
     }
+
 
     /**
      * 중복 채팅방 생성을 방지하기 위한 검증 로직

--- a/src/main/java/com/ani/taku_backend/chatroom/service/query/ChatRoomQueryService.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/service/query/ChatRoomQueryService.java
@@ -62,9 +62,12 @@ public class ChatRoomQueryService {
         chatRoom.validateStatus();
         chatRoom.validateUserAccess(userId);
 
-        // 2. 메타 정보 조회
+        // 2. 메타 정보 조회 및 사용자 접근 검증
         ChatRoomMetaInfo metaInfo = chatRoomMetaRepository.findByChatRoomId(chatRoom.getId())
                 .orElseThrow(() -> new DuckwhoException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+                
+        // 사용자가 채팅방을 나갔는지 확인 (비활성 상태 체크)
+        validateMetaInfoAccess(chatRoom.getId(), userId);
 
         // 3. 필요한 데이터 준비
         ChatRoomUsers users = ChatRoomUsers.fromChatRoom(chatRoom);
@@ -205,7 +208,13 @@ public class ChatRoomQueryService {
         ChatRoomMetaInfo metaInfo = chatRoomMetaRepository.findByChatRoomId(chatRoomId)
                 .orElseThrow(() -> new DuckwhoException(ErrorCode.CHAT_ROOM_NOT_FOUND));
                 
+        // 1. 기본 사용자 권한 검증
         metaInfo.validateUserAccess(userId);
+        
+        // 2. 사용자가 채팅방을 나갔는지 확인 (비활성 상태 체크)
+        if (!metaInfo.getParticipants().isParticipantActive(userId)) {
+            throw new DuckwhoException(ErrorCode.CHAT_ROOM_LEFT_USER);
+        }
     }
 
 
@@ -245,6 +254,15 @@ public class ChatRoomQueryService {
         }
 
         List<ChatRoomMetaInfo> metaInfos = chatRoomMetaRepository.findMetaInfoWithLastMessages(chatRoomIds);
+        
+        // 해당 사용자가 활성 상태인 채팅방만 필터링
+        metaInfos = metaInfos.stream()
+                .filter(metaInfo -> metaInfo.getParticipants().isParticipantActive(userId))
+                .collect(Collectors.toList());
+        
+        if (metaInfos.isEmpty()) {
+            return ChatRoomMetaInfoData.empty();
+        }
         
         ChatRoomMessages lastMessages = ChatRoomMessages.fromMetaInfos(metaInfos);
         UnreadMessageCounts unreadCounts = UnreadMessageCounts.fromMetaInfos(metaInfos, userId, chatRoomIds);

--- a/src/main/java/com/ani/taku_backend/chatroom/service/query/ChatRoomQueryService.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/service/query/ChatRoomQueryService.java
@@ -1,10 +1,13 @@
 package com.ani.taku_backend.chatroom.service.query;
 
+import com.ani.taku_backend.chatroom.contansts.MessageConstants;
 import com.ani.taku_backend.chatroom.domain.constant.ChatRoomStatus;
 import com.ani.taku_backend.chatroom.domain.constant.JangterChatRole;
+import com.ani.taku_backend.chatroom.domain.document.ChatMessage;
 import com.ani.taku_backend.chatroom.domain.document.ChatRoomMetaInfo;
 import com.ani.taku_backend.chatroom.domain.vo.ChatRoomMetaInfoData;
 import com.ani.taku_backend.chatroom.domain.vo.ChatRoomMetaInfos;
+import com.ani.taku_backend.chatroom.dto.response.ChatMessageResponseDTO;
 import com.ani.taku_backend.chatroom.dto.response.ChatRoomCompositeDTO;
 import com.ani.taku_backend.chatroom.dto.response.ChatRoomResponseDTO;
 import com.ani.taku_backend.chatroom.domain.entity.ChatRoom;
@@ -28,6 +31,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
+import java.util.Optional;
 
 /**
  * 채팅방 조회 서비스
@@ -98,42 +102,218 @@ public class ChatRoomQueryService {
         
         ChatRoomUsers users = ChatRoomUsers.fromChatRooms(chatRooms);
         
-        return new ChatRoomCompositeDTO(metaInfos, articleImage, lastMessages, unreadCounts, users, chatRoomDtoConverter);
+        return new ChatRoomCompositeDTO(metaInfos, articleImage, lastMessages, unreadCounts, users, this);
     }
 
 
     public ChatRoomResponseDTO findChatRoom(String roomId, Long userId) {
-
-        ChatRoom chatRoom = validateChatRoomAccess(roomId, userId);
-
-        ChatRoomMetaInfo metaInfo = chatRoomMetaRepository.findByChatRoomId(chatRoom.getId())
-                .orElseThrow(() -> new DuckwhoException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+        // 1. 채팅방 조회 및 검증
+        ChatRoom chatRoom = findAndValidateChatRoom(roomId, userId);
         
-        ChatRoomMessages lastMessages = ChatRoomMessages.of(
-                chatRoom.getId(), 
-                metaInfo.getLastMessage()
-        );
-
-        UnreadMessageCounts unreadCounts = UnreadMessageCounts.of(
-                chatRoom.getId(), 
-                metaInfo.getUnreadCount(userId)
-        );
-
-        List<ProductImageDTO> productImages = duckuJangterRepository.findProductImagesById(List.of(chatRoom.getArticleId()));
-        ArticleImage articleImage = ArticleImage.fromProductImageDTOs(productImages);
+        // 2. 메타 정보 조회
+        ChatRoomMetaInfo metaInfo = findChatRoomMetaInfo(chatRoom.getId());
         
-        ChatRoomUsers users = ChatRoomUsers.fromChatRoom(chatRoom);
-
+        // 3. 필요한 데이터 준비
+        ChatRoomUsers users = prepareUserInfo(chatRoom);
+        ChatRoomMessages lastMessages = prepareLastMessages(chatRoom.getId(), metaInfo);
+        UnreadMessageCounts unreadCounts = prepareUnreadCounts(chatRoom.getId(), userId, metaInfo);
+        ArticleImage articleImage = prepareArticleImage(chatRoom.getArticleId());
+        
+        // 4. 추가 데이터 처리
+        ChatMessageResponseDTO lastMessageDTO = createLastMessageDTO(chatRoom, chatRoom.getId(), lastMessages, metaInfo, users);
+        String articleImageUrl = getArticleImageUrl(chatRoom.getArticleId(), articleImage);
+        Integer unreadCount = getUnreadCount(chatRoom.getId(), unreadCounts);
+        
+        // 5. DTO 변환
         return chatRoomDtoConverter.toResponseDto(
                 chatRoom, 
                 metaInfo, 
                 users,
                 lastMessages, 
                 unreadCounts,
-                articleImage
+                articleImage,
+                lastMessageDTO,
+                articleImageUrl,
+                unreadCount
         );
     }
+    
+    /**
+     * 채팅방 조회 및 기본 검증
+     */
+    private ChatRoom findAndValidateChatRoom(String roomId, Long userId) {
+        ChatRoom chatRoom = chatRoomRepository.findByWsRoomIdWithParticipantsAndUsers(roomId)
+                .orElseThrow(() -> new DuckwhoException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+        
+        validateChatRoomStatus(chatRoom);
+        validateUserAccess(chatRoom, userId);
+        
+        return chatRoom;
+    }
+    
+    /**
+     * 채팅방 상태 검증
+     */
+    private void validateChatRoomStatus(ChatRoom chatRoom) {
+        if (!chatRoom.isValid()) {
+            throw new DuckwhoException(ErrorCode.INACTIVE_CHAT_ROOM);
+        }
+        
+        if (chatRoom.getStatus() != ChatRoomStatus.ACTIVE) {
+            throw new DuckwhoException(ErrorCode.INACTIVE_CHAT_ROOM);
+        }
+    }
+    
+    /**
+     * 사용자 접근 권한 검증
+     */
+    private void validateUserAccess(ChatRoom chatRoom, Long userId) {
+        boolean isParticipant = chatRoom.getParticipants().stream()
+                .anyMatch(p -> p.isUser(userId));
+                
+        if (!isParticipant) {
+            throw new DuckwhoException(ErrorCode.UNAUTHORIZED_ACCESS);
+        }
+    }
+    
+    /**
+     * 메타 정보 조회
+     */
+    private ChatRoomMetaInfo findChatRoomMetaInfo(Long chatRoomId) {
+        return chatRoomMetaRepository.findByChatRoomId(chatRoomId)
+                .orElseThrow(() -> new DuckwhoException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+    }
+    
+    /**
+     * 사용자 정보 준비
+     */
+    private ChatRoomUsers prepareUserInfo(ChatRoom chatRoom) {
+        return ChatRoomUsers.fromChatRoom(chatRoom);
+    }
+    
+    /**
+     * 마지막 메시지 정보 준비
+     */
+    private ChatRoomMessages prepareLastMessages(Long chatRoomId, ChatRoomMetaInfo metaInfo) {
+        return ChatRoomMessages.of(chatRoomId, metaInfo.getLastMessage());
+    }
+    
+    /**
+     * 읽지 않은 메시지 수 준비
+     */
+    private UnreadMessageCounts prepareUnreadCounts(Long chatRoomId, Long userId, ChatRoomMetaInfo metaInfo) {
+        return UnreadMessageCounts.of(chatRoomId, metaInfo.getUnreadCount(userId));
+    }
+    
+    /**
+     * 상품 이미지 준비
+     */
+    private ArticleImage prepareArticleImage(Long articleId) {
+        List<ProductImageDTO> productImages = duckuJangterRepository.findProductImagesById(List.of(articleId));
+        return ArticleImage.fromProductImageDTOs(productImages);
+    }
+    
+    /**
+     * 마지막 메시지 DTO 생성
+     */
+    private ChatMessageResponseDTO createLastMessageDTO(
+            ChatRoom chatRoom,
+            Long chatRoomId,
+            ChatRoomMessages lastMessages,
+            ChatRoomMetaInfo metaInfo,
+            ChatRoomUsers users) {
 
+        if (chatRoomId == null) {
+            return null;
+        }
+
+        Optional<ChatMessage> messageOpt;
+        try {
+            messageOpt = lastMessages != null
+                    ? lastMessages.getLastMessage(chatRoomId)
+                    : Optional.ofNullable(metaInfo != null ? metaInfo.getLastMessage() : null);
+        } catch (Exception e) {
+            log.warn("마지막 메시지 조회 중 오류 발생: chatRoomId={}, error={}", chatRoomId, e.getMessage());
+            return null;
+        }
+
+        if (messageOpt.isEmpty()) {
+            return null;
+        }
+
+        ChatMessage lastMessage = messageOpt.get();
+        if (lastMessage == null || lastMessage.getSenderId() == null) {
+            return null;
+        }
+
+        String senderName = users != null
+                ? users.getUserNicknameOrUnknown(lastMessage.getSenderId())
+                : MessageConstants.UNKNOWN_USER;
+
+        try {
+            return ChatMessageResponseDTO.from(lastMessage, senderName, chatRoom.getWsRoomId());
+        } catch (Exception e) {
+            log.warn("메시지 DTO 생성 중 오류 발생: chatRoomId={}, error={}", chatRoomId, e.getMessage());
+            return null;
+        }
+    }
+    
+    /**
+     * 상품 이미지 URL 조회
+     */
+    private String getArticleImageUrl(Long articleId, ArticleImage articleImage) {
+        if (articleId == null || articleImage == null) {
+            return null;
+        }
+        try {
+            return articleImage.getImageUrl(articleId);
+        } catch (Exception e) {
+            log.warn("상품 이미지 조회 중 오류 발생: articleId={}, error={}", articleId, e.getMessage());
+            return null;
+        }
+    }
+    
+    /**
+     * 읽지 않은 메시지 수 조회
+     */
+    private Integer getUnreadCount(Long chatRoomId, UnreadMessageCounts unreadCounts) {
+        return unreadCounts != null ? unreadCounts.getUnreadCount(chatRoomId) : 0;
+    }
+
+    /**
+     * 채팅방 응답 DTO를 생성합니다.
+     * 각 계산값(lastMessageDTO, articleImageUrl, unreadCount)을 직접 계산하여 DTO 생성에 사용합니다.
+     */
+    public ChatRoomResponseDTO createChatRoomResponseDTO(
+            ChatRoom chatRoom,
+            ChatRoomMetaInfo metaInfo,
+            ChatRoomUsers users,
+            ChatRoomMessages lastMessages,
+            UnreadMessageCounts unreadCounts,
+            ArticleImage articleImage) {
+        
+        // 마지막 메시지 조회
+        ChatMessageResponseDTO lastMessageDTO = createLastMessageDTO(
+            chatRoom, chatRoom.getId(), lastMessages, metaInfo, users);
+        
+        // 이미지 URL 조회
+        String articleImageUrl = getArticleImageUrl(chatRoom.getArticleId(), articleImage);
+        
+        // 읽지 않은 메시지 수 조회
+        Integer unreadCount = getUnreadCount(chatRoom.getId(), unreadCounts);
+        
+        return chatRoomDtoConverter.toResponseDto(
+                chatRoom, 
+                metaInfo, 
+                users,
+                lastMessages, 
+                unreadCounts,
+                articleImage,
+                lastMessageDTO,
+                articleImageUrl,
+                unreadCount
+        );
+    }
 
     public ChatRoom validateChatRoomAccess(String wsRoomId, Long userId) {
         log.debug("채팅방 접근 권한 검증: wsRoomId={}, userId={}", wsRoomId, userId);

--- a/src/main/java/com/ani/taku_backend/chatroom/service/query/ChatRoomQueryService.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/service/query/ChatRoomQueryService.java
@@ -82,6 +82,7 @@ public class ChatRoomQueryService {
         return new SliceImpl<>(responseDTOs, pageable, chatRooms.hasNext());
     }
 
+
     private ChatRoomCompositeDTO aggregateChatRoomData(List<ChatRoom> chatRooms, List<Long> chatRoomIds, Long userId) {
         ChatRoomMetaInfoData metaInfoData = getChatRoomMetaInfoData(chatRoomIds, userId);
         ChatRoomMetaInfos metaInfos = metaInfoData.getMetaInfos();
@@ -97,6 +98,7 @@ public class ChatRoomQueryService {
         
         return new ChatRoomCompositeDTO(metaInfos, articleImage, lastMessages, unreadCounts, users);
     }
+
 
     public ChatRoomResponseDTO findChatRoom(String roomId, Long userId) {
 
@@ -130,6 +132,7 @@ public class ChatRoomQueryService {
         );
     }
 
+
     public ChatRoom validateChatRoomAccess(String wsRoomId, Long userId) {
         log.debug("채팅방 접근 권한 검증: wsRoomId={}, userId={}", wsRoomId, userId);
 
@@ -144,6 +147,7 @@ public class ChatRoomQueryService {
         return chatRoom;
     }
 
+
     public Integer getTotalUnreadCount(Long userId) {
         List<ChatRoomMetaInfo> userChatrooms = chatRoomMetaRepository
                 .findChatRoomMetaInfosByParticipantUserId(userId);
@@ -154,6 +158,7 @@ public class ChatRoomQueryService {
 
         return ChatRoomMetaInfo.calculateTotalUnreadCount(userChatrooms, userId);
     }
+
 
     public List<ChatRoomResponseDTO> findChatRoomListByRole(Long userId, JangterChatRole role) {
         List<ChatRoom> chatRooms = chatRoomRepository.findChatRoomsByUserIdAndRole(
@@ -169,6 +174,7 @@ public class ChatRoomQueryService {
         
         return dataBundle.toChatRoomResponseDTOs(chatRooms);
     }
+
 
     private ChatRoomMetaInfoData getChatRoomMetaInfoData(List<Long> chatRoomIds, Long userId) {
         if (chatRoomIds == null || chatRoomIds.isEmpty()) {

--- a/src/main/java/com/ani/taku_backend/chatroom/service/query/ChatRoomQueryService.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/service/query/ChatRoomQueryService.java
@@ -1,9 +1,7 @@
 package com.ani.taku_backend.chatroom.service.query;
 
-import com.ani.taku_backend.chatroom.contansts.MessageConstants;
 import com.ani.taku_backend.chatroom.domain.constant.ChatRoomStatus;
 import com.ani.taku_backend.chatroom.domain.constant.JangterChatRole;
-import com.ani.taku_backend.chatroom.domain.document.ChatMessage;
 import com.ani.taku_backend.chatroom.domain.document.ChatRoomMetaInfo;
 import com.ani.taku_backend.chatroom.domain.vo.ChatRoomMetaInfoData;
 import com.ani.taku_backend.chatroom.domain.vo.ChatRoomMetaInfos;
@@ -31,7 +29,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -106,7 +103,7 @@ public class ChatRoomQueryService {
         List<Long> chatRoomIds = ChatRoom.extractChatRoomIds(chatRooms.getContent());
         List<Long> articleIds = ChatRoom.extractArticleIds(chatRooms.getContent());
 
-        // 필요한 모든 데이터를 한 번에 조회
+        // 필요한 모든 데이터를 한 번에  조회
         ChatRoomCompositeDTO dataBundle = aggregateChatRoomData(
                 chatRooms.getContent(), chatRoomIds, articleIds, userId);
         
@@ -115,74 +112,6 @@ public class ChatRoomQueryService {
         return new SliceImpl<>(responseDTOs, pageable, chatRooms.hasNext());
     }
 
-
-    /**
-     * 마지막 메시지 DTO 생성
-     */
-    private ChatMessageResponseDTO createLastMessageDTO(
-            ChatRoom chatRoom,
-            Long chatRoomId,
-            ChatRoomMessages lastMessages,
-            ChatRoomMetaInfo metaInfo,
-            ChatRoomUsers users) {
-
-        if (chatRoomId == null) {
-            return null;
-        }
-
-        // 1. 마지막 메시지 조회
-        return getLastMessage(chatRoomId, lastMessages, metaInfo)
-                .filter(msg -> msg.getSenderId() != null)
-                .map(lastMessage -> createResponseDTO(
-                        lastMessage, 
-                        getUserName(users, lastMessage.getSenderId()), 
-                        chatRoom.getWsRoomId(), 
-                        chatRoomId))
-                .orElse(null);
-    }
-
-
-    /**
-     * 채팅방의 마지막 메시지를 조회합니다.
-     */
-    private Optional<ChatMessage> getLastMessage(
-            Long chatRoomId, 
-            ChatRoomMessages lastMessages, 
-            ChatRoomMetaInfo metaInfo) {
-        
-        try {
-            return lastMessages.getLastMessage(chatRoomId)
-                    .or(() -> Optional.ofNullable(metaInfo.getLastMessage()));
-        } catch (Exception e) {
-            log.warn("마지막 메시지 조회 중 오류 발생: chatRoomId={}, error={}", chatRoomId, e.getMessage());
-            return Optional.empty();
-        }
-    }
-    
-    /**
-     * 발신자 이름을 결정합니다.
-     */
-    private String getUserName(ChatRoomUsers users, Long senderId) {
-        return users.getUserNicknameOrUnknown(senderId);
-    }
-    
-    /**
-     * 채팅 메시지 응답 DTO를 생성합니다.
-     */
-    private ChatMessageResponseDTO createResponseDTO(
-            ChatMessage message, 
-            String senderName, 
-            String wsRoomId,
-            Long chatRoomId) {
-        
-        try {
-            return ChatMessageResponseDTO.from(message, senderName, wsRoomId);
-        } catch (Exception e) {
-            log.warn("메시지 DTO 생성 중 오류 발생: chatRoomId={}, error={}", chatRoomId, e.getMessage());
-            return null;
-        }
-    }
-    
     /**
      * 상품 이미지 URL 조회
      */
@@ -215,8 +144,7 @@ public class ChatRoomQueryService {
             ArticleImage articleImage) {
         
         // 마지막 메시지 조회
-        ChatMessageResponseDTO lastMessageDTO = createLastMessageDTO(
-            chatRoom, chatRoom.getId(), lastMessages, metaInfo, users);
+        ChatMessageResponseDTO lastMessageDTO = lastMessages.createLastMessageDTO(chatRoom, metaInfo, users);
         
         // 이미지 URL 조회
         String articleImageUrl = getArticleImageUrl(chatRoom.getArticleId(), articleImage);

--- a/src/main/java/com/ani/taku_backend/chatroom/service/query/ChatRoomQueryService.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/service/query/ChatRoomQueryService.java
@@ -51,6 +51,42 @@ public class ChatRoomQueryService {
 
 
     /**
+     * 특정 채팅방의 정보를 조회합니다.
+     *
+     * @param roomId 채팅방 ID
+     * @param userId 사용자 ID
+     * @return 채팅방 정보
+     */
+    public ChatRoomResponseDTO findChatRoom(String roomId, Long userId) {
+        // 1. 채팅방 조회 및 검증
+        ChatRoom chatRoom = findChatRoomByWsRoomId(roomId);
+
+        chatRoom.validateStatus();
+        chatRoom.validateUserAccess(userId);
+
+        // 2. 메타 정보 조회
+        ChatRoomMetaInfo metaInfo = chatRoomMetaRepository.findByChatRoomId(chatRoom.getId())
+                .orElseThrow(() -> new DuckwhoException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        // 3. 필요한 데이터 준비
+        ChatRoomUsers users = ChatRoomUsers.fromChatRoom(chatRoom);
+        ChatRoomMessages lastMessages = ChatRoomMessages.of(chatRoom.getId(), metaInfo.getLastMessage());
+        UnreadMessageCounts unreadCounts = UnreadMessageCounts.of(chatRoom.getId(), metaInfo.getUnreadCount(userId));
+        ArticleImage articleImage = fetchArticleImagesBatch(List.of(chatRoom.getArticleId()));
+
+        // 4. DTO 변환 및 반환
+        return createChatRoomResponseDTO(
+                chatRoom,
+                metaInfo,
+                users,
+                lastMessages,
+                unreadCounts,
+                articleImage
+        );
+    }
+
+
+    /**
      * 사용자의 채팅방 목록을 페이징하여 조회합니다(무한 스크롤).
      * 
      * @param userId 사용자 ID
@@ -325,7 +361,7 @@ public class ChatRoomQueryService {
     }
     
     /**
-     * 상품 이미지를 배치로 효율적으로 조회합니다.
+     * 상품 이미지를 조회합니다.
      */
     private ArticleImage fetchArticleImagesBatch(List<Long> articleIds) {
         if (articleIds == null || articleIds.isEmpty()) {
@@ -342,4 +378,16 @@ public class ChatRoomQueryService {
         List<ProductImageDTO> productImages = duckuJangterRepository.findProductImagesById(distinctArticleIds);
         return ArticleImage.fromProductImageDTOs(productImages);
     }
+
+    /**
+     * 사용자의 모든 채팅방 목록을 조회합니다.
+     * 
+     * @param userId 사용자 ID
+     * @return 채팅방 응답 DTO 목록
+     */
+    public List<ChatRoomResponseDTO> findChatRoomList(Long userId) {
+        Slice<ChatRoomResponseDTO> slice = findChatRoomListWithSlice(userId, Pageable.unpaged());
+        return slice.getContent();
+    }
+
 }

--- a/src/main/java/com/ani/taku_backend/chatroom/service/query/ChatRoomQueryService.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/service/query/ChatRoomQueryService.java
@@ -14,6 +14,7 @@ import com.ani.taku_backend.chatroom.domain.vo.ArticleImage;
 import com.ani.taku_backend.chatroom.domain.vo.ChatRoomMessages;
 import com.ani.taku_backend.chatroom.domain.vo.ChatRoomUsers;
 import com.ani.taku_backend.chatroom.domain.vo.UnreadMessageCounts;
+import com.ani.taku_backend.chatroom.mapper.ChatRoomDtoConverter;
 import com.ani.taku_backend.common.exception.DuckwhoException;
 import com.ani.taku_backend.common.exception.ErrorCode;
 import com.ani.taku_backend.jangter.model.dto.ProductImageDTO;
@@ -42,6 +43,7 @@ public class ChatRoomQueryService {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatRoomMetaRepository chatRoomMetaRepository;
     private final DuckuJangterRepository duckuJangterRepository;
+    private final ChatRoomDtoConverter chatRoomDtoConverter;
 
 
     public List<ChatRoomResponseDTO> findChatRoomList(Long userId) {
@@ -96,7 +98,7 @@ public class ChatRoomQueryService {
         
         ChatRoomUsers users = ChatRoomUsers.fromChatRooms(chatRooms);
         
-        return new ChatRoomCompositeDTO(metaInfos, articleImage, lastMessages, unreadCounts, users);
+        return new ChatRoomCompositeDTO(metaInfos, articleImage, lastMessages, unreadCounts, users, chatRoomDtoConverter);
     }
 
 
@@ -122,7 +124,7 @@ public class ChatRoomQueryService {
         
         ChatRoomUsers users = ChatRoomUsers.fromChatRoom(chatRoom);
 
-        return ChatRoomResponseDTO.from(
+        return chatRoomDtoConverter.toResponseDto(
                 chatRoom, 
                 metaInfo, 
                 users,

--- a/src/main/java/com/ani/taku_backend/chatroom/service/query/ChatRoomQueryService.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/service/query/ChatRoomQueryService.java
@@ -145,37 +145,12 @@ public class ChatRoomQueryService {
         ChatRoom chatRoom = chatRoomRepository.findByWsRoomIdWithParticipantsAndUsers(roomId)
                 .orElseThrow(() -> new DuckwhoException(ErrorCode.CHAT_ROOM_NOT_FOUND));
         
-        validateChatRoomStatus(chatRoom);
-        validateUserAccess(chatRoom, userId);
+        chatRoom.validateStatus();
+        chatRoom.validateUserAccess(userId);
         
         return chatRoom;
     }
-    
-    /**
-     * 채팅방 상태 검증
-     */
-    private void validateChatRoomStatus(ChatRoom chatRoom) {
-        if (!chatRoom.isValid()) {
-            throw new DuckwhoException(ErrorCode.INACTIVE_CHAT_ROOM);
-        }
-        
-        if (chatRoom.getStatus() != ChatRoomStatus.ACTIVE) {
-            throw new DuckwhoException(ErrorCode.INACTIVE_CHAT_ROOM);
-        }
-    }
-    
-    /**
-     * 사용자 접근 권한 검증
-     */
-    private void validateUserAccess(ChatRoom chatRoom, Long userId) {
-        boolean isParticipant = chatRoom.getParticipants().stream()
-                .anyMatch(p -> p.isUser(userId));
-                
-        if (!isParticipant) {
-            throw new DuckwhoException(ErrorCode.UNAUTHORIZED_ACCESS);
-        }
-    }
-    
+
     /**
      * 메타 정보 조회
      */

--- a/src/main/java/com/ani/taku_backend/chatroom/service/query/ChatRoomQueryService.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/service/query/ChatRoomQueryService.java
@@ -50,20 +50,6 @@ public class ChatRoomQueryService {
     private final ChatRoomDtoConverter chatRoomDtoConverter;
 
 
-    public List<ChatRoomResponseDTO> findChatRoomList(Long userId) {
-        List<ChatRoom> chatRooms = chatRoomRepository.findChatRoomsWithParticipantsAndUsers(userId, ChatRoomStatus.ACTIVE);
-
-        if (chatRooms.isEmpty()) {
-            return List.of();
-        }
-        
-        List<Long> chatRoomIds = ChatRoom.extractChatRoomIds(chatRooms);
-
-        ChatRoomCompositeDTO dataBundle = aggregateChatRoomData(chatRooms, chatRoomIds, userId);
-        
-        return dataBundle.toChatRoomResponseDTOs(chatRooms);
-    }
-
     /**
      * 사용자의 채팅방 목록을 페이징하여 조회합니다(무한 스크롤).
      * 
@@ -187,7 +173,8 @@ public class ChatRoomQueryService {
         List<ProductImageDTO> productImages = duckuJangterRepository.findProductImagesById(List.of(articleId));
         return ArticleImage.fromProductImageDTOs(productImages);
     }
-    
+
+
     /**
      * 마지막 메시지 DTO 생성
      */
@@ -202,31 +189,64 @@ public class ChatRoomQueryService {
             return null;
         }
 
-        Optional<ChatMessage> messageOpt;
-        try {
-            messageOpt = lastMessages != null
-                    ? lastMessages.getLastMessage(chatRoomId)
-                    : Optional.ofNullable(metaInfo != null ? metaInfo.getLastMessage() : null);
-        } catch (Exception e) {
-            log.warn("마지막 메시지 조회 중 오류 발생: chatRoomId={}, error={}", chatRoomId, e.getMessage());
-            return null;
-        }
-
+        // 1. 마지막 메시지 조회
+        Optional<ChatMessage> messageOpt = findLastMessage(chatRoomId, lastMessages, metaInfo);
         if (messageOpt.isEmpty()) {
             return null;
         }
 
+        // 2. 메시지 검증
         ChatMessage lastMessage = messageOpt.get();
-        if (lastMessage == null || lastMessage.getSenderId() == null) {
+        if (lastMessage.getSenderId() == null) {
             return null;
         }
 
-        String senderName = users != null
-                ? users.getUserNicknameOrUnknown(lastMessage.getSenderId())
-                : MessageConstants.UNKNOWN_USER;
+        // 3. 발신자 이름 획득
+        String senderName = resolveSenderName(users, lastMessage.getSenderId());
 
+        // 4. DTO 생성
+        return createResponseDTO(lastMessage, senderName, chatRoom.getWsRoomId(), chatRoomId);
+    }
+
+
+    /**
+     * 채팅방의 마지막 메시지를 조회합니다.
+     */
+    private Optional<ChatMessage> findLastMessage(
+            Long chatRoomId, 
+            ChatRoomMessages lastMessages, 
+            ChatRoomMetaInfo metaInfo) {
+        
         try {
-            return ChatMessageResponseDTO.from(lastMessage, senderName, chatRoom.getWsRoomId());
+            return lastMessages != null
+                    ? lastMessages.getLastMessage(chatRoomId)
+                    : Optional.ofNullable(metaInfo != null ? metaInfo.getLastMessage() : null);
+        } catch (Exception e) {
+            log.warn("마지막 메시지 조회 중 오류 발생: chatRoomId={}, error={}", chatRoomId, e.getMessage());
+            return Optional.empty();
+        }
+    }
+    
+    /**
+     * 발신자 이름을 결정합니다.
+     */
+    private String resolveSenderName(ChatRoomUsers users, Long senderId) {
+        return users != null
+                ? users.getUserNicknameOrUnknown(senderId)
+                : MessageConstants.UNKNOWN_USER;
+    }
+    
+    /**
+     * 채팅 메시지 응답 DTO를 생성합니다.
+     */
+    private ChatMessageResponseDTO createResponseDTO(
+            ChatMessage message, 
+            String senderName, 
+            String wsRoomId,
+            Long chatRoomId) {
+        
+        try {
+            return ChatMessageResponseDTO.from(message, senderName, wsRoomId);
         } catch (Exception e) {
             log.warn("메시지 DTO 생성 중 오류 발생: chatRoomId={}, error={}", chatRoomId, e.getMessage());
             return null;
@@ -295,6 +315,9 @@ public class ChatRoomQueryService {
 
         ChatRoom chatRoom = chatRoomRepository.findByWsRoomIdWithParticipantsAndUsers(wsRoomId)
                 .orElseThrow(() -> new DuckwhoException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        chatRoom.validateStatus();
+        chatRoom.validateUserAccess(userId);
 
         ChatRoomMetaInfo metaInfo = chatRoomMetaRepository.findByChatRoomId(chatRoom.getId())
                 .orElseThrow(() -> new DuckwhoException(ErrorCode.CHAT_ROOM_NOT_FOUND));

--- a/src/main/java/com/ani/taku_backend/chatroom/service/query/ChatRoomQueryService.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/service/query/ChatRoomQueryService.java
@@ -95,7 +95,7 @@ public class ChatRoomQueryService {
      * @return 채팅방 응답 DTO 목록의 Slice
      */
     public Slice<ChatRoomResponseDTO> findChatRoomListWithSlice(Long userId, Pageable pageable) {
-        // 채팅방과 참여자, 사용자를 함께 조회하도록 쿼리 최적화
+        // 채팅방과 참여자, 사용자를 함께 조회
         Slice<ChatRoom> chatRooms = chatRoomRepository.findChatRoomsWithSlice(
                 userId, pageable, ChatRoomStatus.ACTIVE);
 
@@ -106,7 +106,7 @@ public class ChatRoomQueryService {
         List<Long> chatRoomIds = ChatRoom.extractChatRoomIds(chatRooms.getContent());
         List<Long> articleIds = ChatRoom.extractArticleIds(chatRooms.getContent());
 
-        // 필요한 모든 데이터를 한 번에 배치로 조회
+        // 필요한 모든 데이터를 한 번에 조회
         ChatRoomCompositeDTO dataBundle = aggregateChatRoomData(
                 chatRooms.getContent(), chatRoomIds, articleIds, userId);
         

--- a/src/main/java/com/ani/taku_backend/chatroom/service/query/ChatRoomQueryService.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/service/query/ChatRoomQueryService.java
@@ -32,6 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * 채팅방 조회 서비스
@@ -72,7 +73,7 @@ public class ChatRoomQueryService {
         ChatRoomUsers users = ChatRoomUsers.fromChatRoom(chatRoom);
         ChatRoomMessages lastMessages = ChatRoomMessages.of(chatRoom.getId(), metaInfo.getLastMessage());
         UnreadMessageCounts unreadCounts = UnreadMessageCounts.of(chatRoom.getId(), metaInfo.getUnreadCount(userId));
-        ArticleImage articleImage = fetchArticleImagesBatch(List.of(chatRoom.getArticleId()));
+        ArticleImage articleImage = findArticleImage(List.of(chatRoom.getArticleId()));
 
         // 4. DTO 변환 및 반환
         return createChatRoomResponseDTO(
@@ -130,37 +131,28 @@ public class ChatRoomQueryService {
         }
 
         // 1. 마지막 메시지 조회
-        Optional<ChatMessage> messageOpt = findLastMessage(chatRoomId, lastMessages, metaInfo);
-        if (messageOpt.isEmpty()) {
-            return null;
-        }
-
-        // 2. 메시지 검증
-        ChatMessage lastMessage = messageOpt.get();
-        if (lastMessage.getSenderId() == null) {
-            return null;
-        }
-
-        // 3. 발신자 이름 획득
-        String senderName = resolveSenderName(users, lastMessage.getSenderId());
-
-        // 4. DTO 생성
-        return createResponseDTO(lastMessage, senderName, chatRoom.getWsRoomId(), chatRoomId);
+        return getLastMessage(chatRoomId, lastMessages, metaInfo)
+                .filter(msg -> msg.getSenderId() != null)
+                .map(lastMessage -> createResponseDTO(
+                        lastMessage, 
+                        getUserName(users, lastMessage.getSenderId()), 
+                        chatRoom.getWsRoomId(), 
+                        chatRoomId))
+                .orElse(null);
     }
 
 
     /**
      * 채팅방의 마지막 메시지를 조회합니다.
      */
-    private Optional<ChatMessage> findLastMessage(
+    private Optional<ChatMessage> getLastMessage(
             Long chatRoomId, 
             ChatRoomMessages lastMessages, 
             ChatRoomMetaInfo metaInfo) {
         
         try {
-            return lastMessages != null
-                    ? lastMessages.getLastMessage(chatRoomId)
-                    : Optional.ofNullable(metaInfo != null ? metaInfo.getLastMessage() : null);
+            return lastMessages.getLastMessage(chatRoomId)
+                    .or(() -> Optional.ofNullable(metaInfo.getLastMessage()));
         } catch (Exception e) {
             log.warn("마지막 메시지 조회 중 오류 발생: chatRoomId={}, error={}", chatRoomId, e.getMessage());
             return Optional.empty();
@@ -170,10 +162,8 @@ public class ChatRoomQueryService {
     /**
      * 발신자 이름을 결정합니다.
      */
-    private String resolveSenderName(ChatRoomUsers users, Long senderId) {
-        return users != null
-                ? users.getUserNicknameOrUnknown(senderId)
-                : MessageConstants.UNKNOWN_USER;
+    private String getUserName(ChatRoomUsers users, Long senderId) {
+        return users.getUserNicknameOrUnknown(senderId);
     }
     
     /**
@@ -197,9 +187,6 @@ public class ChatRoomQueryService {
      * 상품 이미지 URL 조회
      */
     private String getArticleImageUrl(Long articleId, ArticleImage articleImage) {
-        if (articleId == null || articleImage == null) {
-            return null;
-        }
         try {
             return articleImage.getImageUrl(articleId);
         } catch (Exception e) {
@@ -212,7 +199,7 @@ public class ChatRoomQueryService {
      * 읽지 않은 메시지 수 조회
      */
     private Integer getUnreadCount(Long chatRoomId, UnreadMessageCounts unreadCounts) {
-        return unreadCounts != null ? unreadCounts.getUnreadCount(chatRoomId) : 0;
+        return unreadCounts.getUnreadCount(chatRoomId);
     }
 
     /**
@@ -298,7 +285,7 @@ public class ChatRoomQueryService {
         List<ChatRoomMetaInfo> userChatrooms = chatRoomMetaRepository
                 .findChatRoomMetaInfosByParticipantUserId(userId);
 
-        if (userChatrooms == null || userChatrooms.isEmpty()) {
+        if (userChatrooms.isEmpty()) {
             return 0;
         }
 
@@ -307,7 +294,6 @@ public class ChatRoomQueryService {
 
 
     public List<ChatRoomResponseDTO> findChatRoomListByRole(Long userId, JangterChatRole role) {
-        // 채팅방과 참여자, 사용자를 함께 조회하도록 쿼리 최적화
         List<ChatRoom> chatRooms = chatRoomRepository.findChatRoomsByUserIdAndRole(
                 userId, role, ChatRoomStatus.ACTIVE);
 
@@ -318,7 +304,6 @@ public class ChatRoomQueryService {
         List<Long> chatRoomIds = ChatRoom.extractChatRoomIds(chatRooms);
         List<Long> articleIds = ChatRoom.extractArticleIds(chatRooms);
 
-        // 필요한 모든 데이터를 한 번에 배치로 조회
         ChatRoomCompositeDTO dataBundle = aggregateChatRoomData(
                 chatRooms, chatRoomIds, articleIds, userId);
         
@@ -327,11 +312,10 @@ public class ChatRoomQueryService {
 
 
     private ChatRoomMetaInfoData getChatRoomMetaInfoData(List<Long> chatRoomIds, Long userId) {
-        if (chatRoomIds == null || chatRoomIds.isEmpty()) {
+        if (chatRoomIds.isEmpty()) {
             return ChatRoomMetaInfoData.empty();
         }
 
-        // 한 번의 쿼리로 모든 메타 정보 조회 (마지막 메시지 포함)
         List<ChatRoomMetaInfo> metaInfos = chatRoomMetaRepository.findMetaInfoWithLastMessages(chatRoomIds);
         
         ChatRoomMessages lastMessages = ChatRoomMessages.fromMetaInfos(metaInfos);
@@ -349,7 +333,7 @@ public class ChatRoomQueryService {
         ChatRoomMetaInfoData metaInfoData = getChatRoomMetaInfoData(chatRoomIds, userId);
         ChatRoomMetaInfos metaInfos = metaInfoData.getMetaInfos();
 
-        ArticleImage articleImage = fetchArticleImagesBatch(articleIds);
+        ArticleImage articleImage = findArticleImage(articleIds);
         
         ChatRoomMessages lastMessages = metaInfoData.getLastMessages();
         UnreadMessageCounts unreadCounts = metaInfoData.getUnreadCounts();
@@ -363,8 +347,8 @@ public class ChatRoomQueryService {
     /**
      * 상품 이미지를 조회합니다.
      */
-    private ArticleImage fetchArticleImagesBatch(List<Long> articleIds) {
-        if (articleIds == null || articleIds.isEmpty()) {
+    private ArticleImage findArticleImage(List<Long> articleIds) {
+        if (articleIds.isEmpty()) {
             return ArticleImage.empty();
         }
         
@@ -372,7 +356,11 @@ public class ChatRoomQueryService {
         List<Long> distinctArticleIds = articleIds.stream()
                 .filter(Objects::nonNull)
                 .distinct()
-                .collect(java.util.stream.Collectors.toList());
+                .collect(Collectors.toList());
+        
+        if (distinctArticleIds.isEmpty()) {
+            return ArticleImage.empty();
+        }
         
         // 모든 상품 이미지 조회
         List<ProductImageDTO> productImages = duckuJangterRepository.findProductImagesById(distinctArticleIds);

--- a/src/main/java/com/ani/taku_backend/chatroom/service/query/ChatRoomQueryService.java
+++ b/src/main/java/com/ani/taku_backend/chatroom/service/query/ChatRoomQueryService.java
@@ -58,6 +58,7 @@ public class ChatRoomQueryService {
      * @return 채팅방 응답 DTO 목록의 Slice
      */
     public Slice<ChatRoomResponseDTO> findChatRoomListWithSlice(Long userId, Pageable pageable) {
+        // 채팅방과 참여자, 사용자를 함께 조회하도록 쿼리 최적화
         Slice<ChatRoom> chatRooms = chatRoomRepository.findChatRoomsWithSlice(
                 userId, pageable, ChatRoomStatus.ACTIVE);
 
@@ -66,112 +67,15 @@ public class ChatRoomQueryService {
         }
         
         List<Long> chatRoomIds = ChatRoom.extractChatRoomIds(chatRooms.getContent());
+        List<Long> articleIds = ChatRoom.extractArticleIds(chatRooms.getContent());
 
-        ChatRoomCompositeDTO dataBundle = aggregateChatRoomData(chatRooms.getContent(), chatRoomIds, userId);
+        // 필요한 모든 데이터를 한 번에 배치로 조회
+        ChatRoomCompositeDTO dataBundle = aggregateChatRoomData(
+                chatRooms.getContent(), chatRoomIds, articleIds, userId);
         
         List<ChatRoomResponseDTO> responseDTOs = dataBundle.toChatRoomResponseDTOs(chatRooms.getContent());
         
         return new SliceImpl<>(responseDTOs, pageable, chatRooms.hasNext());
-    }
-
-
-    private ChatRoomCompositeDTO aggregateChatRoomData(List<ChatRoom> chatRooms, List<Long> chatRoomIds, Long userId) {
-        ChatRoomMetaInfoData metaInfoData = getChatRoomMetaInfoData(chatRoomIds, userId);
-        ChatRoomMetaInfos metaInfos = metaInfoData.getMetaInfos();
-        
-        List<Long> articleIds = ChatRoom.extractArticleIds(chatRooms);
-        List<ProductImageDTO> productImages = duckuJangterRepository.findProductImagesById(articleIds);
-        ArticleImage articleImage = ArticleImage.fromProductImageDTOs(productImages);
-        
-        ChatRoomMessages lastMessages = metaInfoData.getLastMessages();
-        UnreadMessageCounts unreadCounts = metaInfoData.getUnreadCounts();
-        
-        ChatRoomUsers users = ChatRoomUsers.fromChatRooms(chatRooms);
-        
-        return new ChatRoomCompositeDTO(metaInfos, articleImage, lastMessages, unreadCounts, users, this);
-    }
-
-
-    public ChatRoomResponseDTO findChatRoom(String roomId, Long userId) {
-        // 1. 채팅방 조회 및 검증
-        ChatRoom chatRoom = findAndValidateChatRoom(roomId, userId);
-        
-        // 2. 메타 정보 조회
-        ChatRoomMetaInfo metaInfo = findChatRoomMetaInfo(chatRoom.getId());
-        
-        // 3. 필요한 데이터 준비
-        ChatRoomUsers users = prepareUserInfo(chatRoom);
-        ChatRoomMessages lastMessages = prepareLastMessages(chatRoom.getId(), metaInfo);
-        UnreadMessageCounts unreadCounts = prepareUnreadCounts(chatRoom.getId(), userId, metaInfo);
-        ArticleImage articleImage = prepareArticleImage(chatRoom.getArticleId());
-        
-        // 4. 추가 데이터 처리
-        ChatMessageResponseDTO lastMessageDTO = createLastMessageDTO(chatRoom, chatRoom.getId(), lastMessages, metaInfo, users);
-        String articleImageUrl = getArticleImageUrl(chatRoom.getArticleId(), articleImage);
-        Integer unreadCount = getUnreadCount(chatRoom.getId(), unreadCounts);
-        
-        // 5. DTO 변환
-        return chatRoomDtoConverter.toResponseDto(
-                chatRoom, 
-                metaInfo, 
-                users,
-                lastMessages, 
-                unreadCounts,
-                articleImage,
-                lastMessageDTO,
-                articleImageUrl,
-                unreadCount
-        );
-    }
-    
-    /**
-     * 채팅방 조회 및 기본 검증
-     */
-    private ChatRoom findAndValidateChatRoom(String roomId, Long userId) {
-        ChatRoom chatRoom = chatRoomRepository.findByWsRoomIdWithParticipantsAndUsers(roomId)
-                .orElseThrow(() -> new DuckwhoException(ErrorCode.CHAT_ROOM_NOT_FOUND));
-        
-        chatRoom.validateStatus();
-        chatRoom.validateUserAccess(userId);
-        
-        return chatRoom;
-    }
-
-    /**
-     * 메타 정보 조회
-     */
-    private ChatRoomMetaInfo findChatRoomMetaInfo(Long chatRoomId) {
-        return chatRoomMetaRepository.findByChatRoomId(chatRoomId)
-                .orElseThrow(() -> new DuckwhoException(ErrorCode.CHAT_ROOM_NOT_FOUND));
-    }
-    
-    /**
-     * 사용자 정보 준비
-     */
-    private ChatRoomUsers prepareUserInfo(ChatRoom chatRoom) {
-        return ChatRoomUsers.fromChatRoom(chatRoom);
-    }
-    
-    /**
-     * 마지막 메시지 정보 준비
-     */
-    private ChatRoomMessages prepareLastMessages(Long chatRoomId, ChatRoomMetaInfo metaInfo) {
-        return ChatRoomMessages.of(chatRoomId, metaInfo.getLastMessage());
-    }
-    
-    /**
-     * 읽지 않은 메시지 수 준비
-     */
-    private UnreadMessageCounts prepareUnreadCounts(Long chatRoomId, Long userId, ChatRoomMetaInfo metaInfo) {
-        return UnreadMessageCounts.of(chatRoomId, metaInfo.getUnreadCount(userId));
-    }
-    
-    /**
-     * 상품 이미지 준비
-     */
-    private ArticleImage prepareArticleImage(Long articleId) {
-        List<ProductImageDTO> productImages = duckuJangterRepository.findProductImagesById(List.of(articleId));
-        return ArticleImage.fromProductImageDTOs(productImages);
     }
 
 
@@ -313,18 +217,44 @@ public class ChatRoomQueryService {
     public ChatRoom validateChatRoomAccess(String wsRoomId, Long userId) {
         log.debug("채팅방 접근 권한 검증: wsRoomId={}, userId={}", wsRoomId, userId);
 
-        ChatRoom chatRoom = chatRoomRepository.findByWsRoomIdWithParticipantsAndUsers(wsRoomId)
-                .orElseThrow(() -> new DuckwhoException(ErrorCode.CHAT_ROOM_NOT_FOUND));
-
+        // 1. 채팅방 조회
+        ChatRoom chatRoom = findChatRoomByWsRoomId(wsRoomId);
+        
+        // 2. 채팅방 상태 및 사용자 권한 검증
         chatRoom.validateStatus();
         chatRoom.validateUserAccess(userId);
-
-        ChatRoomMetaInfo metaInfo = chatRoomMetaRepository.findByChatRoomId(chatRoom.getId())
-                .orElseThrow(() -> new DuckwhoException(ErrorCode.CHAT_ROOM_NOT_FOUND));
-
-        metaInfo.validateUserAccess(userId);
+        
+        // 3. 메타 정보 검증
+        validateMetaInfoAccess(chatRoom.getId(), userId);
         
         return chatRoom;
+    }
+    
+    /**
+     * WebSocket 룸 ID로 채팅방을 조회합니다.
+     * 
+     * @param wsRoomId WebSocket 룸 ID
+     * @return 조회된 채팅방
+     * @throws DuckwhoException 채팅방을 찾을 수 없는 경우
+     */
+    private ChatRoom findChatRoomByWsRoomId(String wsRoomId) {
+        return chatRoomRepository.findByWsRoomIdWithParticipantsAndUsers(wsRoomId)
+                .orElseThrow(() -> new DuckwhoException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+    }
+
+    
+    /**
+     * 채팅방 메타 정보의 접근 권한을 검증합니다.
+     * 
+     * @param chatRoomId 채팅방 ID
+     * @param userId 사용자 ID
+     * @throws DuckwhoException 메타 정보를 찾을 수 없거나 접근 권한이 없는 경우
+     */
+    private void validateMetaInfoAccess(Long chatRoomId, Long userId) {
+        ChatRoomMetaInfo metaInfo = chatRoomMetaRepository.findByChatRoomId(chatRoomId)
+                .orElseThrow(() -> new DuckwhoException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+                
+        metaInfo.validateUserAccess(userId);
     }
 
 
@@ -341,6 +271,7 @@ public class ChatRoomQueryService {
 
 
     public List<ChatRoomResponseDTO> findChatRoomListByRole(Long userId, JangterChatRole role) {
+        // 채팅방과 참여자, 사용자를 함께 조회하도록 쿼리 최적화
         List<ChatRoom> chatRooms = chatRoomRepository.findChatRoomsByUserIdAndRole(
                 userId, role, ChatRoomStatus.ACTIVE);
 
@@ -349,8 +280,11 @@ public class ChatRoomQueryService {
         }
 
         List<Long> chatRoomIds = ChatRoom.extractChatRoomIds(chatRooms);
+        List<Long> articleIds = ChatRoom.extractArticleIds(chatRooms);
 
-        ChatRoomCompositeDTO dataBundle = aggregateChatRoomData(chatRooms, chatRoomIds, userId);
+        // 필요한 모든 데이터를 한 번에 배치로 조회
+        ChatRoomCompositeDTO dataBundle = aggregateChatRoomData(
+                chatRooms, chatRoomIds, articleIds, userId);
         
         return dataBundle.toChatRoomResponseDTOs(chatRooms);
     }
@@ -361,11 +295,51 @@ public class ChatRoomQueryService {
             return ChatRoomMetaInfoData.empty();
         }
 
+        // 한 번의 쿼리로 모든 메타 정보 조회 (마지막 메시지 포함)
         List<ChatRoomMetaInfo> metaInfos = chatRoomMetaRepository.findMetaInfoWithLastMessages(chatRoomIds);
         
         ChatRoomMessages lastMessages = ChatRoomMessages.fromMetaInfos(metaInfos);
         UnreadMessageCounts unreadCounts = UnreadMessageCounts.fromMetaInfos(metaInfos, userId, chatRoomIds);
 
         return new ChatRoomMetaInfoData(metaInfos, lastMessages, unreadCounts);
+    }
+
+    private ChatRoomCompositeDTO aggregateChatRoomData(
+            List<ChatRoom> chatRooms, 
+            List<Long> chatRoomIds, 
+            List<Long> articleIds, 
+            Long userId) {
+
+        ChatRoomMetaInfoData metaInfoData = getChatRoomMetaInfoData(chatRoomIds, userId);
+        ChatRoomMetaInfos metaInfos = metaInfoData.getMetaInfos();
+
+        ArticleImage articleImage = fetchArticleImagesBatch(articleIds);
+        
+        ChatRoomMessages lastMessages = metaInfoData.getLastMessages();
+        UnreadMessageCounts unreadCounts = metaInfoData.getUnreadCounts();
+        
+        // 사용자 정보 준비
+        ChatRoomUsers users = ChatRoomUsers.fromChatRooms(chatRooms);
+        
+        return new ChatRoomCompositeDTO(metaInfos, articleImage, lastMessages, unreadCounts, users, this);
+    }
+    
+    /**
+     * 상품 이미지를 배치로 효율적으로 조회합니다.
+     */
+    private ArticleImage fetchArticleImagesBatch(List<Long> articleIds) {
+        if (articleIds == null || articleIds.isEmpty()) {
+            return ArticleImage.empty();
+        }
+        
+        // 중복 제거 및 null 필터링
+        List<Long> distinctArticleIds = articleIds.stream()
+                .filter(Objects::nonNull)
+                .distinct()
+                .collect(java.util.stream.Collectors.toList());
+        
+        // 모든 상품 이미지 조회
+        List<ProductImageDTO> productImages = duckuJangterRepository.findProductImagesById(distinctArticleIds);
+        return ArticleImage.fromProductImageDTOs(productImages);
     }
 }

--- a/src/main/java/com/ani/taku_backend/common/exception/ErrorCode.java
+++ b/src/main/java/com/ani/taku_backend/common/exception/ErrorCode.java
@@ -78,8 +78,10 @@ public enum ErrorCode {
     // Chat
     DUPLICATE_CHAT_ROOM(40903, HttpStatus.CONFLICT, "이미 존재하는 채팅방입니다."),
     CHAT_ROOM_NOT_FOUND(40407, HttpStatus.NOT_FOUND, "존재하지 않는 채팅방입니다."),
+    INACTIVE_CHAT_ROOM(40320, HttpStatus.FORBIDDEN, "비활성화된 채팅방입니다."),
     INVALID_CHAT_USER(40408, HttpStatus.NOT_FOUND, "채팅방에 존재할 수 없는 유저입니다."),
     CHAT_MESSAGE_NOT_FOUND(40412, HttpStatus.NOT_FOUND, "존재하지 않는 채팅 메시지입니다."),
+   
 
     // Category Bookmark
     NOT_FOUND_CATEGORY_BOOKMARK(40409, HttpStatus.NOT_FOUND, "존재하지 않는 카테고리 북마크입니다."),

--- a/src/main/java/com/ani/taku_backend/common/exception/ErrorCode.java
+++ b/src/main/java/com/ani/taku_backend/common/exception/ErrorCode.java
@@ -81,7 +81,7 @@ public enum ErrorCode {
     INACTIVE_CHAT_ROOM(40320, HttpStatus.FORBIDDEN, "비활성화된 채팅방입니다."),
     INVALID_CHAT_USER(40408, HttpStatus.NOT_FOUND, "채팅방에 존재할 수 없는 유저입니다."),
     CHAT_MESSAGE_NOT_FOUND(40412, HttpStatus.NOT_FOUND, "존재하지 않는 채팅 메시지입니다."),
-   
+    CHAT_ROOM_LEFT_USER(40321, HttpStatus.FORBIDDEN, "이미 나간 채팅방입니다."),
 
     // Category Bookmark
     NOT_FOUND_CATEGORY_BOOKMARK(40409, HttpStatus.NOT_FOUND, "존재하지 않는 카테고리 북마크입니다."),

--- a/src/main/java/com/ani/taku_backend/config/ModelMapperConfig.java
+++ b/src/main/java/com/ani/taku_backend/config/ModelMapperConfig.java
@@ -11,7 +11,6 @@ import com.ani.taku_backend.category.domain.entity.Category;
 import com.ani.taku_backend.category.domain.entity.CategoryImage;
 import com.ani.taku_backend.category.domain.entity.CategoryGenre;
 import com.ani.taku_backend.category.domain.dto.ResponseCategorySeachDTO;
-import org.modelmapper.Converter;
 import java.util.List;
 import java.util.ArrayList;
 

--- a/src/main/java/com/ani/taku_backend/jangter/model/entity/DuckuJangter.java
+++ b/src/main/java/com/ani/taku_backend/jangter/model/entity/DuckuJangter.java
@@ -2,6 +2,8 @@ package com.ani.taku_backend.jangter.model.entity;
 
 import com.ani.taku_backend.common.baseEntity.BaseTimeEntity;
 import com.ani.taku_backend.common.enums.StatusType;
+import com.ani.taku_backend.common.exception.DuckwhoException;
+import com.ani.taku_backend.common.exception.ErrorCode;
 import com.ani.taku_backend.common.model.entity.Image;
 import com.ani.taku_backend.jangter.model.dto.ProductUpdateRequestDTO;
 import com.ani.taku_backend.jangter.model.enums.ProductStatus;
@@ -136,6 +138,30 @@ public class DuckuJangter extends BaseTimeEntity {
 
     public boolean isOwner(Long userId) {
         return this.user != null && this.user.getUserId().equals(userId);
+    }
+    
+    /**
+     * 채팅방 생성을 위한 상품 상태 검증
+     * 상품이 판매 중 상태가 아니면 예외를 발생시킵니다.
+     * 
+     * @throws DuckwhoException 상품이 판매 중이 아닌 경우
+     */
+    public void validateForChatRoom() {
+        if (this.status != ProductStatus.FOR_SALE) {
+            throw new DuckwhoException(ErrorCode.INVALID_PRODUCT_STATUS);
+        }
+    }
+    
+    /**
+     * 판매자와 구매자가 동일인물인지 검증합니다.
+     * 
+     * @param buyerId 구매자 ID
+     * @throws DuckwhoException 판매자와 구매자가 동일인물인 경우
+     */
+    public void validateDifferentUsers(Long buyerId) {
+        if (this.user != null && this.user.getUserId().equals(buyerId)) {
+            throw new DuckwhoException(ErrorCode.INVALID_CHAT_USER);
+        }
     }
 
 }


### PR DESCRIPTION
# [Refactor] DTO에서 비즈니스 로직 분리 및 도메인 책임 강화

## 📌 Description

이 PR은 DDD 원칙에 따라 DTO에서 비즈니스 로직을 분리하고, 각 책임에 맞는 계층으로 이동하는 리팩토링 작업입니다.  
특히 `ChatRoomResponseDTO` 내부에 있던 로직이 리팩토링의 출발점이었습니다.

DTO는 본래 계층 간 **데이터 전달**만 담당해야 하며, VO와 달리  **비즈니스 로직이 포함되면 안 됩니다**.  
기존 `ChatRoomResponseDTO`는 273줄이 넘는 코드에 `ResponseDTOBuilder` 클래스와 다양한 비즈니스 로직 메서드가 섞여 있었고, 이로 인해 가독성과 유지보수성이 크게 떨어지는 상황이었습니다.

### 기존 ChatRoomResponseDTO의 문제점

#### 🔸 단일 책임 원칙(SRP) 위반
- DTO가 데이터 전송 외에도 복잡한 변환 로직까지 담당
- 내부 `ResponseDTOBuilder`가 비즈니스 로직까지 처리
- 로깅, 예외 처리, 객체 변환 등 여러 책임이 한 클래스에 집중

#### 🔸 유지보수 어려움
- 273줄 이상의 비대한 클래스 크기로 이해하기 어려움
- 기능 변경 시 영향 범위 파악이 복잡해짐
- 내부 클래스 구조로 인해 코드 따라가기 어려움

#### 🔸 도메인 지식 유출
- 도메인 규칙이 DTO까지 노출되어 계층 간 경계가 모호해짐
- `createLastMessageDTO()`, `getArticleImageUrl()` 등 비즈니스 로직 포함
- DTO가 다양한 도메인 객체에 대한 지식을 가지고 있음

#### 🔸 오류 처리 취약성
- 내부 로직에서 예외가 발생해도 `null`을 반환하는 방식 사용
- 다양한 `try-catch` 블록으로 코드 복잡도 증가
- 로깅은 있지만 명확한 오류 전파 메커니즘 부재


---

## 🔧 Changes

### 1. DTO와 비즈니스 로직 분리
- `ChatRoomDtoConverter` 클래스 추가 (`mapper` 패키지)
- `ChatRoomResponseDTO`는 불변 객체로 변경하여, **순수 데이터 컨테이너**로만 사용
- 모든 DTO에서 비즈니스 로직 완전히 제거

### 2. 계층 책임 명확화
- 서비스 계층(`ChatRoomQueryService`, `ChatRoomCommandService`)에서 `DtoConverter` 사용
- `ChatRoomCompositeDTO`에 `DtoConverter` 주입 및 활용
- `ChatRoomDtoConverter` 내부에 남아 있던 로직은 서비스 계층으로 위임

### 3. 도메인 모델 책임 강화
- 검증 로직을 서비스에서 도메인 객체로 이동
- 참여자 상태 변경 로직도 도메인 객체로 이전
- `ChatRoomMessages` VO에 `createLastMessageDTO()` 메서드 추가
- 메시지 처리 로직을 서비스 → 도메인 계층으로 이동

### 4. 성능 및 코드 품질 개선
- 채팅방 조회 시 발생하던 **N+1 문제 최적화**
- 중복된 채팅방 목록 조회 메서드 제거 및 재사용
- 불필요한 `null` 체크 제거로 코드 깔끔하게 정리
- `Optional`, Stream API를 활용한 함수형 스타일 코드 적용
- VO의 null-safe 특성을 적극 활용
- 중복 검사 로직 개선 및 간결화
- 나간 채팅방 관련 예외 처리 강화

---

## 🤔 왜 ModelMapper 대신 mapper 레이어를 도입해 수동 매핑(`ChatRoomDtoConverter`)을 썼나요?

config.modelmapperconfig가 있지만 다음과 같은 이유로 chatroom 내에 mapper 레이어를 도입했습니다.

| 이유 | 설명 |
|------|------|
| **복잡한 변환 처리** | `ChatRoom` 도메인은 여러 객체(ChatRoom, ChatRoomMetaInfo, Users 등)를 엮어야 하는 복합 구조입니다. 단순 매핑 도구인 ModelMapper로는 처리하기 어렵습니다. |
| **컴파일 타임 안정성** | ModelMapper는 리플렉션 기반이라 런타임에야 오류를 발견할 수 있지만, 수동 매핑은 컴파일 타임에 오류를 확인할 수 있어 안정적입니다. |
| **성능 고려** | ModelMapper는 리플렉션 사용으로 성능 오버헤드가 발생할 수 있습니다. 수동 매핑은 성능 면에서도 유리합니다. |
| **도메인 특화 로직 표현** | 채팅방에는 읽음 처리, 메시지 처리 등 도메인 특화 규칙이 있어 명시적인 수동 매핑이 더 적합합니다. |
| **DDD 원칙 준수** | DTO와 도메인 간 변환은 응용 계층의 책임이며, 각 계층의 역할을 명확히 나누는 것이 도메인 순수성을 지키는 핵심입니다. |


## Screenshots
.

## Ref
.
